### PR TITLE
Replaced Model_Reset

### DIFF
--- a/totalRP3_Extended/inventory/inventory_page.lua
+++ b/totalRP3_Extended/inventory/inventory_page.lua
@@ -37,7 +37,7 @@ local DEFAULT_TIME = 1;
 local function resetEquip(Main, Model)
 	local main = Main or main;
 	local model = Model or model;
-	Model_Reset(model);
+	model:ResetModel();
 	if main.Equip then
 		main.Equip:Hide();
 	end


### PR DESCRIPTION
Model_Reset is disappearing in 8.2, replaced by ResetModel in a mixin.