### PR TITLE
Fixes for music changes in 8.2

### DIFF
--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -266,7 +266,8 @@ local EFFECTS = {
 	["sound_music_self"] = {
 		method = function(structure, cArgs, eArgs)
 			local path = cArgs[1] or "";
-			eArgs.LAST = TRP3_API.utils.music.playMusic(path);
+			local musicID = tonumber(path) or TRP3_API.utils.music.convertPathToID(path) or path;
+			eArgs.LAST = TRP3_API.utils.music.playMusic(musicID);
 		end,
 		secured = security.HIGH,
 	},
@@ -314,17 +315,18 @@ local EFFECTS = {
 	["sound_music_local"] = {
 		getCArgs = function(args)
 			local musicPath = args[1] or "";
+			local musicID = tonumber(path) or TRP3_API.utils.music.convertPathToID(path) or path;
 			local distance = tonumber(args[2] or 0);
 			local source = "Script"; -- TODO: get source
-			return musicPath, distance, source;
+			return musicID, distance, source;
 		end,
 		method = function(structure, cArgs, eArgs)
-			local musicPath, distance, source = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.utils.music.playLocalMusic(musicPath, distance, source);
+			local musicID, distance, source = structure.getCArgs(cArgs);
+			eArgs.LAST = TRP3_API.utils.music.playLocalMusic(musicID, distance, source);
 		end,
 		securedMethod = function(structure, cArgs, eArgs)
-			local musicPath = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.utils.music.playMusic(musicPath);
+			local musicID = structure.getCArgs(cArgs);
+			eArgs.LAST = TRP3_API.utils.music.playMusic(musicID);
 		end,
 		secured = security.MEDIUM,
 	},

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -850,10 +850,10 @@ local function sound_music_self_init()
 		icon = "inv_misc_drum_07",
 		description = loc.EFFECT_SOUND_MUSIC_SELF_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
-			scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_MUSIC_SELF_PREVIEW:format("|cff00ff00" .. tostring(args[1])));
+			scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_MUSIC_SELF_PREVIEW:format("|cff00ff00" .. (Utils.music.getTitle(tonumber(args[1])) or tostring(args[1])));
 		end,
 		getDefaultArgs = function()
-			return {"zonemusic\\brewfest\\BF_Goblins1"};
+			return {"228575"};
 		end,
 		editor = soundMusicEditor,
 	});
@@ -1009,11 +1009,11 @@ local function sound_music_local_init()
 		description = loc.EFFECT_SOUND_MUSIC_LOCAL_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
 			scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_MUSIC_LOCAL_PREVIEW:format(
-			"|cff00ff00" .. tostring(args[1]) .. "|cffffff00", "|cff00ff00" .. tostring(args[2]) .. "|cffffff00"
+			"|cff00ff00" .. (Utils.music.getTitle(tonumber(args[1])) or tostring(args[1])) .. "|cffffff00", "|cff00ff00" .. tostring(args[2]) .. "|cffffff00"
 			));
 		end,
 		getDefaultArgs = function()
-			return {"zonemusic\\brewfest\\BF_Goblins1", 20};
+			return {"228575", 20};
 		end,
 		editor = musicLocalEditor,
 	});


### PR DESCRIPTION
Default behaviour for musics will now be to use IDs, but for the sake of simplicity, paths will still be accepted and converted into IDs in the effect. Easier than going through all the hierarchies to convert them on flyway/import/reception...