### PR TITLE
Added ModelFrameMixin to the inspection model

### DIFF
--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -157,6 +157,7 @@ function inspectionFrame.init()
 
 	-- Slots
 	Model_OnLoad(inspectionFrame.Main.Model, nil, nil, 0);
+	Mixin(inspectionFrame.Main.Model, ModelFrameMixin);
 	inspectionFrame.Main.slots = {};
 	for i=1, 16 do
 		local button = CreateFrame("Button", "TRP3_InspectionFrameSlot" .. i, inspectionFrame.Main, "TRP3_InventoryPageSlotTemplate");


### PR DESCRIPTION
This solves the issue where ResetModel doesn't exist on the inspection frame model because it doesn't inherit from the same template. The function is now part of this mixin, so I applied it to the inspection model.