### PR TITLE
Use functions calls from the ModelFrameMixin

### DIFF
--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -156,8 +156,8 @@ function inspectionFrame.init()
 	loadingTemplate = loc.INV_PAGE_CHARACTER_INSPECTION .. ": %0.2f %%";
 
 	-- Slots
-	Model_OnLoad(inspectionFrame.Main.Model, nil, nil, 0);
 	Mixin(inspectionFrame.Main.Model, ModelFrameMixin);
+	inspectionFrame.Main.Model:OnLoad(nil, nil, 0);
 	inspectionFrame.Main.slots = {};
 	for i=1, 16 do
 		local button = CreateFrame("Button", "TRP3_InspectionFrameSlot" .. i, inspectionFrame.Main, "TRP3_InventoryPageSlotTemplate");

--- a/totalRP3_Extended/inventory/inventory.xml
+++ b/totalRP3_Extended/inventory/inventory.xml
@@ -387,10 +387,10 @@
 							<OnEnter function=""/>
 							<OnLeave function=""/>
 							<OnMouseUp>
-								self.onMouseUpFunc(self, button);
+								self:OnMouseUp(button);
 							</OnMouseUp>
 							<OnMouseDown>
-								Model_OnMouseDown(self, button);
+								self:OnMouseDown(button);
 							</OnMouseDown>
 							<OnMouseWheel function=""/>
 						</Scripts>


### PR DESCRIPTION
self.onMouseUpFunc was nil, so I went and looked for the mixin function. I updated a couple of other function calls which, while working at the moment, might be replaced like Model_Reset was. Better to use the new functions.