### PR TITLE
Removed call for Patreon supporters

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1778,8 +1778,4 @@ Created by |cff00ff00Sylvain "Telkostrasz" Cossement|r and |cff00ff00Renaud "Ell
 - Zencore
 
 ##  You are the best!
-
-## Total RP 3: Extended is also maintained thanks to Ellypse's [Patreon](http://patreon.com/Ellypse) supporters:
-
-%s
 ]];

--- a/totalRP3_Extended_Tools/list/list.lua
+++ b/totalRP3_Extended_Tools/list/list.lua
@@ -416,7 +416,7 @@ local function onTabChanged(tabWidget, tab)
 		ToolFrame.list.filters:Hide();
 		ToolFrame.list.backers:Show();
 
-		ToolFrame.list.backers.child.HTML:SetText(Utils.str.toHTML(TRP3_KS_BACKERS:format(TRP3_API.extended.tools.formatVersion(), TRP3_API.Ellyb:GetPatreonSupporters())));
+		ToolFrame.list.backers.child.HTML:SetText(Utils.str.toHTML(TRP3_KS_BACKERS:format(TRP3_API.extended.tools.formatVersion())));
 		ToolFrame.list.backers.child.HTML:SetScript("OnHyperlinkClick", function(self, url, text, button)
 			TRP3_API.Ellyb.Popups:OpenURL(url);
 		end)


### PR DESCRIPTION
The Credits tab was broken since Patreon supporters were removed from Ellyb. Locale key is only in English directly in the code, so no localization change to make in Curseforge.