### PR TITLE
Don't move stash on save anymore

### DIFF
--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -214,7 +214,7 @@ local function saveStash()
 		};
 		tinsert(stashesData, stash);
 		index = #stashesData;
-		newStash = true;
+		isNewStash = true;
 	end
 	stash.BA.IC = stashEditFrame.icon.selectedIcon or "TEMP";
 	stash.BA.NA = stEtN(strtrim(stashEditFrame.name:GetText():sub(1, 50))) or loc.DR_STASHES_NAME;

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -233,8 +233,8 @@ local function saveStash()
 		stash.uiMapID = mapID;
 		stash.mapX = mapX;
 		stash.mapY = mapY;
-		stash.id = Utils.str.id();
 	end
+	stash.id = Utils.str.id();
 
 	stashEditFrame:Hide();
 

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -226,7 +226,7 @@ local function saveStash()
 	local mapX, mapY = AddOn_TotalRP3.Map.getPlayerCoordinates();
 
 	-- If it's not a new stash, we don't want to replace its position, we can always consider a "move stash" option later
-	if not newStash and posX and posY then
+	if not isNewStash and posX and posY then
 		stash.posX = posX;
 		stash.posY = posY;
 		stash.posZ = posZ;

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -205,6 +205,7 @@ local function saveStash()
 	if index then
 		stash = stashesData[index];
 	end
+	local newStash;
 	if not stash then
 		stash = {
 			BA = {},
@@ -213,6 +214,7 @@ local function saveStash()
 		};
 		tinsert(stashesData, stash);
 		index = #stashesData;
+		newStash = true;
 	end
 	stash.BA.IC = stashEditFrame.icon.selectedIcon or "TEMP";
 	stash.BA.NA = stEtN(strtrim(stashEditFrame.name:GetText():sub(1, 50))) or loc.DR_STASHES_NAME;
@@ -223,7 +225,8 @@ local function saveStash()
 	local mapID = AddOn_TotalRP3.Map.getPlayerMapID();
 	local mapX, mapY = AddOn_TotalRP3.Map.getPlayerCoordinates();
 
-	if posX and posY then
+	-- If it's not a new stash, we don't want to replace its position, we can always consider a "move stash" option later
+	if not newStash and posX and posY then
 		stash.posX = posX;
 		stash.posY = posY;
 		stash.posZ = posZ;

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -205,7 +205,7 @@ local function saveStash()
 	if index then
 		stash = stashesData[index];
 	end
-	local newStash;
+	local isNewStash;
 	if not stash then
 		stash = {
 			BA = {},


### PR DESCRIPTION
This was an issue only really noticeable since the added dropdown when right-clicking a stash icon on the map scan: saving a stash currently replaces the position, mapID and ID of the stash if the position exists.

Editing stashes should likely not move them, although we might consider adding an option to move a stash later if it feels needed (or if the distance between the old and the new position is small enough).

On the other hand, the ID should have been changed even if the position doesn't exist. It's unlikely to ever cause problem, but modifying the content of a stash in an instance map after someone started accessing it could cause syncing issues. Really specific case but might as well tighten it up.