### PR TITLE
Variable tags for target info

### DIFF
--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -761,6 +761,34 @@ directReplacement = {
 		local defaultRace = UnitRace("player");
 		return TRP3_API.profile.getData("player/characteristics").RA or defaultRace or UNKNOWN;
 	end,
+	["trp:target:first"] = function()
+		if UnitIsUnit("target", "player") then
+			return directReplacement["trp:player:first"]();
+		end
+		local defaultName = UnitName("target");
+		local unitID = getUnitID("target");
+		if unitID and isUnitIDKnown(unitID) then
+			local profile = getUnitIDCurrentProfile(unitID);
+			if profile and profile.characteristics and profile.characteristics.FN then
+				return profile.characteristics.FN;
+			end
+		end
+		return defaultName or SPELL_FAILED_BAD_IMPLICIT_TARGETS;
+	end,
+	["trp:target:last"] = function()
+		if UnitIsUnit("target", "player") then
+			return directReplacement["trp:player:last"]();
+		end
+		local defaultName = UnitName("target");
+		local unitID = getUnitID("target");
+		if unitID and isUnitIDKnown(unitID) then
+			local profile = getUnitIDCurrentProfile(unitID);
+			if profile and profile.characteristics and profile.characteristics.LN then
+				return profile.characteristics.LN;
+			end
+		end
+		return defaultName or SPELL_FAILED_BAD_IMPLICIT_TARGETS;
+	end,
 	["trp:target:class"] = function()
 		if UnitIsUnit("target", "player") then
 			return directReplacement["trp:player:class"]();

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -23,6 +23,7 @@ local EMPTY = TRP3_API.globals.empty;
 local assert, type, tostring, error, tonumber, pairs, loadstring, wipe, strsplit = assert, type, tostring, error, tonumber, pairs, loadstring, wipe, strsplit;
 local tableCopy = TRP3_API.utils.table.copy;
 local log, logLevel = TRP3_API.utils.log.log, TRP3_API.utils.log.level;
+local getUnitID, isUnitIDKnown, getUnitIDCurrentProfile = TRP3_API.utils.str.getUnitID, TRP3_API.register.isUnitIDKnown, TRP3_API.register.getUnitIDCurrentProfile;
 local writeElement;
 local loc = TRP3_API.loc;
 
@@ -765,9 +766,12 @@ directReplacement = {
 			return directReplacement["trp:player:class"]();
 		end
 		local defaultClass = UnitClass("target");
-		local profile = TRP3_API.register.getUnitCurrentProfile("target");
-		if profile and profile.characteristics and profile.characteristics.CL then
-			return profile.characteristics.CL;
+		local unitID = getUnitID("target");
+		if unitID and isUnitIDKnown(unitID) then
+			local profile = getUnitIDCurrentProfile(unitID);
+			if profile and profile.characteristics and profile.characteristics.CL then
+				return profile.characteristics.CL;
+			end
 		end
 		return defaultClass or SPELL_FAILED_BAD_IMPLICIT_TARGETS;
 	end,
@@ -776,9 +780,12 @@ directReplacement = {
 			return directReplacement["trp:player:race"]();
 		end
 		local defaultRace = UnitClass("target");
-		local profile = TRP3_API.register.getUnitCurrentProfile("target");
-		if profile and profile.characteristics and profile.characteristics.RA then
-			return profile.characteristics.RA;
+		local unitID = getUnitID("target");
+		if unitID and isUnitIDKnown(unitID) then
+			local profile = getUnitIDCurrentProfile(unitID);
+			if profile and profile.characteristics and profile.characteristics.RA then
+				return profile.characteristics.RA;
+			end
 		end
 		return defaultRace or SPELL_FAILED_BAD_IMPLICIT_TARGETS;
 	end,


### PR DESCRIPTION
Using the variable tags to get the target's race or class wasn't working, as getUnitCurrentProfile is not a real function. Fixed it by getting the unitID from "target" (naming is wonky), then calling getUnitIDCurrentProfile on it.

As a bonus, as was pointed out to me on Discord, there weren't tags to get first or last name of your target, so I added that as well. It will return UnitName result as a default in case no profile could be found.