### PR TITLE
Parse variables when responding to an inspection request

### DIFF
--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -22,6 +22,7 @@ local getClass, isContainerByClassID, isUsableByClass = TRP3_API.extended.getCla
 local loc = TRP3_API.loc;
 local EMPTY = TRP3_API.globals.empty;
 local CreateFrame = CreateFrame;
+local parseArgs = TRP3_API.script.parseArgs;
 
 local inspectionFrame = TRP3_InspectionFrame;
 local decorateSlot;
@@ -69,6 +70,7 @@ end
 local function receiveRequest(request, sender)
 	local reservedMessageID = request[1];
 	local playerInventory = TRP3_API.inventory.getInventory();
+	local campaignStorage = TRP3_API.quest.getCampaignVarStorage();
 
 	local response = {
 		totalWeight = playerInventory.totalWeight,
@@ -79,17 +81,30 @@ local function receiveRequest(request, sender)
 		-- Don't send the default bag
 		if slotID ~= "17" then
 			local class = getClass(slot.id);
+
+			-- Parsing arguments in the item info
+			local parsedBA = {};
+			Utils.table.copy(class.BA, parsedBA);
+			parsedBA.RI = parseArgs(parsedBA.RI, campaignStorage);
+			parsedBA.LE = parseArgs(parsedBA.LE, campaignStorage);
+			parsedBA.DE = parseArgs(parsedBA.DE, campaignStorage);
+
 			response.slots[slotID] = {
 				count = slot.count,
 				id = slot.id,
-				BA = class.BA,
+				BA = parsedBA,
 				pos = slot.pos,
 			};
 			if isContainerByClassID(slot.id) then
 				response.slots[slotID].CO = class.CO;
 			end
 			if isUsableByClass(class) then
-				response.slots[slotID].US = class.US;
+				-- Parsing arguments in the use text
+				local parsedUS = {};
+				Utils.table.copy(class.US, parsedUS);
+				parsedUS.AC = parseArgs(parsedUS.AC, campaignStorage);
+
+				response.slots[slotID].US = parsedUS;
 			end
 		end
 	end

--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -70,7 +70,6 @@ end
 local function receiveRequest(request, sender)
 	local reservedMessageID = request[1];
 	local playerInventory = TRP3_API.inventory.getInventory();
-	local campaignStorage = TRP3_API.quest.getCampaignVarStorage();
 
 	local response = {
 		totalWeight = playerInventory.totalWeight,
@@ -81,13 +80,14 @@ local function receiveRequest(request, sender)
 		-- Don't send the default bag
 		if slotID ~= "17" then
 			local class = getClass(slot.id);
+			local slotInfo = { object = slot };
 
 			-- Parsing arguments in the item info
 			local parsedBA = {};
 			Utils.table.copy(class.BA, parsedBA);
-			parsedBA.RI = parseArgs(parsedBA.RI, campaignStorage);
-			parsedBA.LE = parseArgs(parsedBA.LE, campaignStorage);
-			parsedBA.DE = parseArgs(parsedBA.DE, campaignStorage);
+			parsedBA.RI = parseArgs(parsedBA.RI, slotInfo);
+			parsedBA.LE = parseArgs(parsedBA.LE, slotInfo);
+			parsedBA.DE = parseArgs(parsedBA.DE, slotInfo);
 
 			response.slots[slotID] = {
 				count = slot.count,
@@ -102,7 +102,7 @@ local function receiveRequest(request, sender)
 				-- Parsing arguments in the use text
 				local parsedUS = {};
 				Utils.table.copy(class.US, parsedUS);
-				parsedUS.AC = parseArgs(parsedUS.AC, campaignStorage);
+				parsedUS.AC = parseArgs(parsedUS.AC, slotInfo);
 
 				response.slots[slotID].US = parsedUS;
 			end

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -788,7 +788,7 @@ directReplacement = {
 }
 
 function TRP3_API.script.parseArgs(text, args)
-    if not text return end;
+    if not text then return end;
 	args = args or EMPTY;
 	text = tostring(text) or "";
 	text = text:gsub("%$%{(.-)%}", function(capture)

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -788,7 +788,7 @@ directReplacement = {
 }
 
 function TRP3_API.script.parseArgs(text, args)
-    if not text then return end;
+	if not text then return end;
 	args = args or EMPTY;
 	text = tostring(text) or "";
 	text = text:gsub("%$%{(.-)%}", function(capture)

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -788,6 +788,7 @@ directReplacement = {
 }
 
 function TRP3_API.script.parseArgs(text, args)
+    if not text return end;
 	args = args or EMPTY;
 	text = tostring(text) or "";
 	text = text:gsub("%$%{(.-)%}", function(capture)


### PR DESCRIPTION
When receiving an inspection request, the item info sent to the inspector is the raw database info. This means variables in item info will be parsed on reception without values to match, only showing variable names or default values.

As inspection data is not saved in the database, we can parse the variables before sending them to the inspector, which will show the same item info as the player he inspects would see. Table copy is required as to not modify the database content.

The fields we parse match the "Item info" fields listed here:
https://github.com/Total-RP/Total-RP-3-Extended/wiki/Variable-tags#item