### PR TITLE
Replaced deprecated playuisound calls

### DIFF
--- a/totalRP3_Extended/dialogues/dialogues.xml
+++ b/totalRP3_Extended/dialogues/dialogues.xml
@@ -368,7 +368,7 @@
 				</Anchors>
 				<Scripts>
 					<PostClick>
-						TRP3_API.ui.misc.playUISound("gsCharacterSelection");
+						TRP3_API.ui.misc.playUISound(808);
 					</PostClick>
 				</Scripts>
 			</Button>

--- a/totalRP3_Extended/misc/sounds.xml
+++ b/totalRP3_Extended/misc/sounds.xml
@@ -84,7 +84,7 @@
 				</Anchors>
 				<Scripts>
 					<PostClick>
-						TRP3_API.ui.misc.playUISound("gsCharacterSelection");
+						TRP3_API.ui.misc.playUISound(808);
 					</PostClick>
 				</Scripts>
 			</Button>

--- a/totalRP3_Extended_Tools/main.xml
+++ b/totalRP3_Extended_Tools/main.xml
@@ -307,7 +307,7 @@
 		</HighlightTexture>
 		<Scripts>
 			<PostClick>
-				TRP3_API.ui.misc.playUISound("gsCharacterSelection");
+				TRP3_API.ui.misc.playUISound(808);
 			</PostClick>
 		</Scripts>
 	</Button>


### PR DESCRIPTION
These calls are incorrect since 8.2 and only found now. No corresponding key in the SOUNDKIT global table so it'll have to be numeric.