### PR TITLE
Quest and step copy/paste

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1644,6 +1644,12 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 	EFFECT_DO_EMOTE_SPOKEN = "Spoken",
 	EFFECT_DO_EMOTE_ANIMATED = "Animated",
 	EFFECT_DO_EMOTE_OTHER =  "Others",
+	CA_QUEST_DD_COPY = "Copy quest content",
+	CA_QUEST_DD_PASTE = "Paste quest content",
+	CA_QUEST_DD_REMOVE = "Remove quest",
+	QE_STEP_DD_COPY = "Copy step content",
+	QE_STEP_DD_PASTE = "Paste step content",
+	QE_STEP_DD_REMOVE = "Remove step",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/campaign/editor/normal.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/normal.lua
@@ -42,7 +42,7 @@ local linksEditor = TRP3_LinksEditor;
 local scriptEditor = TRP3_ScriptEditorNormal;
 local innerEditor = TRP3_InnerObjectEditor;
 
-local questClipboard;
+local questClipboard = {};
 local questClipboardID;
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -374,9 +374,6 @@ end
 
 local function onQuestDropdown(value, line)
 	if value == 1 then
-		if not questClipboard then
-			questClipboard = {};
-		end
 		wipe(questClipboard);
 		questClipboardID = getFullID(toolFrame.fullClassID, line.questID);
 		Utils.table.copy(questClipboard, toolFrame.specificDraft.QE[line.questID]);
@@ -385,7 +382,6 @@ local function onQuestDropdown(value, line)
 		TRP3_API.extended.tools.replaceID(questClipboard, questClipboardID, getFullID(toolFrame.fullClassID, line.questID));
 		Utils.table.copy(toolFrame.specificDraft.QE[line.questID], questClipboard);
 		wipe(questClipboard);
-		questClipboard = nil;
 		refreshQuestsList();
 	elseif value == 3 then
 		removeQuest(line.questID);
@@ -550,7 +546,7 @@ function TRP3_API.extended.tools.initCampaignEditorNormal(ToolFrame)
 				local context = {};
 				tinsert(context, {self.questID});
 				tinsert(context, {loc.CA_QUEST_DD_COPY, 1});
-				if questClipboard then
+				if next(questClipboard) then
 					tinsert(context, {loc.CA_QUEST_DD_PASTE, 2});
 				end
 				tinsert(context, {loc.CA_QUEST_DD_REMOVE, 3});

--- a/totalRP3_Extended_Tools/campaign/editor/normal.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/normal.lua
@@ -42,6 +42,9 @@ local linksEditor = TRP3_LinksEditor;
 local scriptEditor = TRP3_ScriptEditorNormal;
 local innerEditor = TRP3_InnerObjectEditor;
 
+local questClipboard;
+local questClipboardID;
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- NPC
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -369,6 +372,26 @@ local function createTabBar()
 	);
 end
 
+local function onQuestDropdown(value, line)
+	if value == 1 then
+		if not questClipboard then
+			questClipboard = {};
+		end
+		wipe(questClipboard);
+		questClipboardID = getFullID(toolFrame.fullClassID, line.questID);
+		Utils.table.copy(questClipboard, toolFrame.specificDraft.QE[line.questID]);
+	elseif value == 2 then
+		wipe(toolFrame.specificDraft.QE[line.questID]);
+		TRP3_API.extended.tools.replaceID(questClipboard, questClipboardID, getFullID(toolFrame.fullClassID, line.questID));
+		Utils.table.copy(toolFrame.specificDraft.QE[line.questID], questClipboard);
+		wipe(questClipboard);
+		questClipboard = nil;
+		refreshQuestsList();
+	elseif value == 3 then
+		removeQuest(line.questID);
+	end
+end
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- INIT
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -524,7 +547,14 @@ function TRP3_API.extended.tools.initCampaignEditorNormal(ToolFrame)
 		tinsert(quests.list.widgetTab, line);
 		line.click:SetScript("OnClick", function(self, button)
 			if button == "RightButton" then
-				removeQuest(self.questID);
+				local context = {};
+				tinsert(context, {self.questID});
+				tinsert(context, {loc.CA_QUEST_DD_COPY, 1});
+				if questClipboard then
+					tinsert(context, {loc.CA_QUEST_DD_PASTE, 2});
+				end
+				tinsert(context, {loc.CA_QUEST_DD_REMOVE, 3});
+				TRP3_API.ui.listbox.displayDropDown(line.click, context, onQuestDropdown, 0, true);
 			else
 				if IsControlKeyDown() then
 					renameQuest(self.questID);
@@ -545,7 +575,7 @@ function TRP3_API.extended.tools.initCampaignEditorNormal(ToolFrame)
 		setTooltipForSameFrame(line.click, "RIGHT", 0, 5, loc.TYPE_QUEST,
 			("|cffffff00%s: |cff00ff00%s\n"):format(loc.CM_CLICK, loc.CM_EDIT)
 			.. ("|cffffff00%s: |cff00ff00%s\n"):format(loc.CM_CTRL .. " + " .. loc.CM_CLICK, loc.CA_QE_ID)
-			.. ("|cffffff00%s: |cff00ff00%s"):format(loc.CM_R_CLICK, REMOVE));
+			.. ("|cffffff00%s: |cff00ff00%s"):format(loc.CM_R_CLICK, loc.CA_ACTIONS));
 	end
 	quests.list.decorate = decorateQuestLine;
 	TRP3_API.ui.list.handleMouseWheel(quests.list, quests.list.slider);

--- a/totalRP3_Extended_Tools/campaign/editor/quest.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/quest.lua
@@ -39,7 +39,7 @@ local TABS = {
 local tabGroup, currentTab, linksStructure;
 local actionEditor = TRP3_ActionsEditorFrame;
 
-local stepClipboard;
+local stepClipboard = {};
 local stepClipboardID;
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -347,9 +347,6 @@ end
 
 local function onStepDropdown(value, line)
 	if value == 1 then
-		if not stepClipboard then
-			stepClipboard = {};
-		end
 		wipe(stepClipboard);
 		stepClipboardID = getFullID(toolFrame.fullClassID, line.stepID);
 		Utils.table.copy(stepClipboard, toolFrame.specificDraft.ST[line.stepID]);
@@ -358,7 +355,6 @@ local function onStepDropdown(value, line)
 		TRP3_API.extended.tools.replaceID(stepClipboard, stepClipboardID, getFullID(toolFrame.fullClassID, line.stepID));
 		Utils.table.copy(toolFrame.specificDraft.ST[line.stepID], stepClipboard);
 		wipe(stepClipboard);
-		stepClipboard = nil;
 		refreshQuestStepList();
 	elseif value == 3 then
 		removeQuestStep(line.stepID);
@@ -505,7 +501,7 @@ function TRP3_API.extended.tools.initQuest(ToolFrame)
 				local context = {};
 				tinsert(context, {self.stepID});
 				tinsert(context, {loc.QE_STEP_DD_COPY, 1});
-				if stepClipboard then
+				if next(stepClipboard) then
 					tinsert(context, {loc.QE_STEP_DD_PASTE, 2});
 				end
 				tinsert(context, {loc.QE_STEP_DD_REMOVE, 3});


### PR DESCRIPTION
#172 
Similar to how items, campaigns and workflow blocks can be copied, I added the option to copy quests and steps.
Right-click now opens a dropdown with copy/paste and remove instead of removing directly.
Inner items of the quest/step have their IDs converted.