### PR TITLE
Cast delay fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -167,6 +167,7 @@ read_globals = {
 	"SetCursor",
 	"SetView",
 	"SPELL_FAILED_BAD_IMPLICIT_TARGETS",
+	"SPELL_FAILED_CASTER_AURASTATE",
 	"SPELL_FAILED_MOVING",
 	"SpellBook_GetSpellBookSlot",
 	"SpellBookFrame",

--- a/totalRP3_Extended/misc/cast.lua
+++ b/totalRP3_Extended/misc/cast.lua
@@ -49,8 +49,13 @@ local function interrupt()
 end
 
 function TRP3_API.extended.showCastingBar(duration, interruptMode, class, soundID, castText)
-	if GetUnitSpeed("player") > 0 then
+	if GetUnitSpeed("player") > 0 and interruptMode == 2 then
 		Utils.message.displayMessage(SPELL_FAILED_MOVING, 4);
+		return;
+	end
+
+	if frame.casting then
+		Utils.message.displayMessage(SPELL_FAILED_CASTER_AURASTATE, 4);
 		return;
 	end
 


### PR DESCRIPTION
Fixes #22 and #170 
- If a cast is not interrupted by movement, it is now possible to start the cast while the player is moving
- If a cast is currently happening, another cast cannot be started until the current one finishes (or is interrupted). I need to think about whether I want to make it possible for casts to be overlapped as they currently are, if I want to add an effect to interrupt the current cast, or something else.