### PR TITLE
Input callback now properly from hardware event

### DIFF
--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -491,20 +491,22 @@ local EFFECTS = {
 	-- PROMPT
 	["var_prompt"] = {
 		method = function(structure, cArgs, eArgs) -- luacheck: ignore 212
-			TRP3_API.popup.showTextInputPopup(cArgs[1] or "",
-			function(value)
-				TRP3_API.script.setVar(eArgs, cArgs[3] or "o", "=", cArgs[2] or "var", value);
-				if cArgs[4] and cArgs[4] ~= "" then
-					TRP3_API.script.setVar(eArgs, "w", "=", cArgs[2] or "var", value);
-					C_Timer.After(0.1, function() TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]) end);
-				end
-			end,
-			function()
-				if cArgs[4] and cArgs[4] ~= "" then
-					C_Timer.After(0.1, function() TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]) end);
-				end
-			end, "");
+			C_Timer.After(0.1, function()
+				TRP3_API.popup.showTextInputPopup(cArgs[1] or "",
+				function(value)
+					TRP3_API.script.setVar(eArgs, cArgs[3] or "o", "=", cArgs[2] or "var", value);
+					if cArgs[4] and cArgs[4] ~= "" then
+						TRP3_API.script.setVar(eArgs, "w", "=", cArgs[2] or "var", value);
+						TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4])
+					end
+				end,
+				function()
+					if cArgs[4] and cArgs[4] ~= "" then
+						TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]);
+					end
+				end, "");
 			eArgs.LAST = 0;
+			end);
 		end,
 		secured = security.HIGH,
 	},


### PR DESCRIPTION
A long time ago, there was an issue when trying to prompt for input in a previous prompt for input effect callback. To solve this issue, I added a small delay between confirming the input and executing the callback workflow.

Unfortunately, this caused an issue after 8.2.5 where input callbacks couldn't use speech effects anymore. To resolve the matter, I am moving the delay before the input window is shown instead, so that input callbacks can once again be instant after hardware effect and trigger speech effects while still letting successive prompts work properly.