### PR TITLE
Sound fadeout on stop

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1650,7 +1650,7 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 	EFFECT_SOUND_ID_FADEOUT = "Fadeout duration (optional)",
 	EFFECT_SOUND_ID_FADEOUT_TT = "The duration (in seconds) over which the sound will be stopped.\n\nLeave empty to stop immediately.",
 	EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW = "Stops sound ID %s in channel %s over %s seconds.",
-	EFFECT_SOUND_ID_STOP_FADEOUT_ALL_PREVIEW = "Stops |cff00ff00all|cffffff00 sounds in channel %s over %s seconds.",
+	EFFECT_SOUND_ID_STOP_FADEOUT_ALL_PREVIEW = "Stops |cff00ff00all|r sounds in channel %s over %s seconds.",
 	OP_OP_DATE_DAY = "Date: Day",
 	OP_OP_DATE_DAY_TT = "The current day, local time.",
 	OP_OP_DATE_MONTH = "Date: Month",

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1647,14 +1647,16 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
-	OP_OP_DATE_DAY = "Date: Day";
-	OP_OP_DATE_DAY_TT = "The current day, local time.";
-	OP_OP_DATE_MONTH = "Date: Month";
-	OP_OP_DATE_MONTH_TT = "The current month, local time.";
-	OP_OP_DATE_YEAR = "Date: Year";
-	OP_OP_DATE_YEAR_TT = "The current year, local time.";
-	OP_OP_DATE_DAY_OF_WEEK = "Date: Day of the week";
-	OP_OP_DATE_DAY_OF_WEEK_TT = "The current day of the week, local time. From 1 (Sunday) to 7 (Saturday).";
+	EFFECT_SOUND_ID_FADEOUT = "Fadeout duration (optional)",
+	EFFECT_SOUND_ID_FADEOUT_TT = "The duration (in seconds) over which the sound will be stopped.\n\nLeave empty to stop immediately.",
+	OP_OP_DATE_DAY = "Date: Day",
+	OP_OP_DATE_DAY_TT = "The current day, local time.",
+	OP_OP_DATE_MONTH = "Date: Month",
+	OP_OP_DATE_MONTH_TT = "The current month, local time.",
+	OP_OP_DATE_YEAR = "Date: Year",
+	OP_OP_DATE_YEAR_TT = "The current year, local time.",
+	OP_OP_DATE_DAY_OF_WEEK = "Date: Day of the week",
+	OP_OP_DATE_DAY_OF_WEEK_TT = "The current day of the week, local time. From 1 (Sunday) to 7 (Saturday).",
 	OP_OP_INV_NAME = "Item name",
 	OP_OP_INV_NAME_PREVIEW = "Name of %s",
 	OP_OP_INV_NAME_TT = "|cff00ff00The name of the item with the given ID.",

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1649,6 +1649,8 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 
 	EFFECT_SOUND_ID_FADEOUT = "Fadeout duration (optional)",
 	EFFECT_SOUND_ID_FADEOUT_TT = "The duration (in seconds) over which the sound will be stopped.\n\nLeave empty to stop immediately.",
+	EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW = "Stops sound ID %s in channel %s over %s seconds.",
+	EFFECT_SOUND_ID_STOP_FADEOUT_ALL_PREVIEW = "Stops |cff00ff00all|cffffff00 sounds in channel %s over %s seconds.",
 	OP_OP_DATE_DAY = "Date: Day",
 	OP_OP_DATE_DAY_TT = "The current day, local time.",
 	OP_OP_DATE_MONTH = "Date: Month",

--- a/totalRP3_Extended/misc/sounds.lua
+++ b/totalRP3_Extended/misc/sounds.lua
@@ -63,9 +63,10 @@ function Utils.music.playLocalMusic(soundID, distance)
 	end
 end
 
-function Utils.music.stopLocalSoundID(soundID, channel)
+function Utils.music.stopLocalSoundID(soundID, channel, fadeout)
 	soundID = soundID or 0;
-	Communications.broadcast.broadcast(LOCAL_STOPSOUND_COMMAND, soundID, channel);
+	fadeout = fadeout or 0;
+	Communications.broadcast.broadcast(LOCAL_STOPSOUND_COMMAND, soundID, channel, fadeout);
 end
 
 function Utils.music.stopLocalMusic(soundID)
@@ -147,9 +148,10 @@ local function initSharedSound()
 		end
 	end);
 
-	Communications.broadcast.registerCommand(LOCAL_STOPSOUND_COMMAND, function(sender, soundID, channel)
+	Communications.broadcast.registerCommand(LOCAL_STOPSOUND_COMMAND, function(sender, soundID, channel, fadeout)
 		if getConfigValue(TRP3_API.extended.CONFIG_SOUNDS_ACTIVE) then
-			Utils.music.stopSoundID(soundID, channel, sender);
+			fadeout = (fadeout or 0) * 1000
+			Utils.music.stopSoundID(soundID, channel, sender, fadeout);
 		end
 	end);
 

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -295,11 +295,12 @@ local EFFECTS = {
 		getCArgs = function(args)
 			local soundID = tonumber(args[2] or 0);
 			local channel = args[1] or "SFX";
-			return soundID, channel;
+			local fadeout = args[3] or 0;
+			return soundID, channel, fadeout;
 		end,
 		method = function(structure, cArgs, eArgs)
-			local soundID, channel = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.utils.music.stopSoundID(soundID, channel);
+			local soundID, channel, fadeout = structure.getCArgs(cArgs);
+			eArgs.LAST = TRP3_API.utils.music.stopSoundID(soundID, channel, fadeout * 1000);
 		end,
 		secured = security.HIGH,
 	},
@@ -353,10 +354,11 @@ local EFFECTS = {
 		getCArgs = function(args)
 			local soundID = tonumber(args[2] or 0);
 			local channel = args[1] or "SFX";
-			return soundID, channel;
+			local fadeout = args[3] or 0;
+			return soundID, channel, fadeout;
 		end,
 		method = function(structure, cArgs, eArgs)
-			local soundID, channel = structure.getCArgs(cArgs);
+			local soundID, channel, fadeout = structure.getCArgs(cArgs);
 			eArgs.LAST = TRP3_API.utils.music.stopLocalSoundID(soundID, channel);
 		end,
 		secured = security.HIGH,

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -300,7 +300,7 @@ local EFFECTS = {
 		end,
 		method = function(structure, cArgs, eArgs)
 			local soundID, channel, fadeout = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.utils.music.stopSoundID(soundID, channel, fadeout * 1000);
+			eArgs.LAST = TRP3_API.utils.music.stopSoundID(soundID, channel, nil, fadeout * 1000);
 		end,
 		secured = security.HIGH,
 	},

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -359,7 +359,7 @@ local EFFECTS = {
 		end,
 		method = function(structure, cArgs, eArgs)
 			local soundID, channel, fadeout = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.utils.music.stopLocalSoundID(soundID, channel);
+			eArgs.LAST = TRP3_API.utils.music.stopLocalSoundID(soundID, channel, fadeout);
 		end,
 		secured = security.HIGH,
 	},

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -978,9 +978,17 @@ local function sound_id_stop_init()
 		description = loc.EFFECT_SOUND_ID_STOP_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
 			if args[2] then
-				scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+				if args[3] then
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+				else
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+				end
 			else
-				scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r"));
+				if args[3] then
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+				else
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r"));
+				end
 			end
 		end,
 		getDefaultArgs = function()
@@ -1154,9 +1162,17 @@ local function sound_id_local_stop_init()
 		description = loc.EFFECT_SOUND_ID_LOCAL_STOP_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
 			if args[2] then
-				scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+				if args[3] then
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+				else
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+				end
 			else
-				scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r"));
+				if args[3] then
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+				else
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_ALL_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r"));
+				end
 			end
 		end,
 		getDefaultArgs = function()

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -979,9 +979,9 @@ local function sound_id_stop_init()
 		effectFrameDecorator = function(scriptStepFrame, args)
 			if args[2] then
 				if args[3] then
-					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|r", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
 				else
-					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|r", "|cff00ff00" .. tostring(args[1]) .. "|r"));
 				end
 			else
 				if args[3] then
@@ -1163,9 +1163,9 @@ local function sound_id_local_stop_init()
 		effectFrameDecorator = function(scriptStepFrame, args)
 			if args[2] then
 				if args[3] then
-					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_FADEOUT_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|r", "|cff00ff00" .. tostring(args[1]) .. "|r", "|cff00ff00" .. tostring(args[3]) .. "|r"));
 				else
-					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|cffffff00", "|cff00ff00" .. tostring(args[1]) .. "|r"));
+					scriptStepFrame.description:SetText("|cffffff00" .. loc.EFFECT_SOUND_ID_STOP_PREVIEW:format("|cff00ff00" .. tostring(args[2]) .. "|r", "|cff00ff00" .. tostring(args[1]) .. "|r"));
 				end
 			else
 				if args[3] then

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -984,7 +984,7 @@ local function sound_id_stop_init()
 			end
 		end,
 		getDefaultArgs = function()
-			return {"SFX", nil};
+			return {"SFX", nil, nil};
 		end,
 		editor = SoundIDStopEditor,
 	});
@@ -1000,6 +1000,10 @@ local function sound_id_stop_init()
 	SoundIDStopEditor.id.title:SetText(loc.EFFECT_SOUND_ID_SELF_ID);
 	setTooltipForSameFrame(SoundIDStopEditor.id.help, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_SELF_ID, loc.EFFECT_SOUND_ID_STOP_ID_TT);
 
+	-- Fadeout
+	SoundIDStopEditor.fadeout.title:SetText(loc.EFFECT_SOUND_ID_FADEOUT);
+	setTooltipForSameFrame(SoundIDStopEditor.id.help, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_FADEOUT, loc.EFFECT_SOUND_ID_FADEOUT_TT);
+
 	SoundIDStopEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	SoundIDStopEditor.play:SetScript("OnClick", function(self)
 		local soundID = tonumber(strtrim(SoundIDStopEditor.id:GetText()));
@@ -1012,11 +1016,19 @@ local function sound_id_stop_init()
 		local data = scriptData.args or Globals.empty;
 		SoundIDStopEditor.channel:SetSelectedValue(data[1] or "SFX");
 		SoundIDStopEditor.id:SetText(data[2] or "");
+		SoundIDStopEditor.fadeout:SetText(data[3] or "");
 	end
 
 	function SoundIDStopEditor.save(scriptData)
 		scriptData.args[1] = SoundIDStopEditor.channel:GetSelectedValue() or "SFX";
 		scriptData.args[2] = tonumber(strtrim(SoundIDStopEditor.id:GetText()));
+		if scriptData.args[2] == 0 then
+			scriptData.args[2] = nil;
+		end
+		scriptData.args[3] = tonumber(strtrim(SoundIDStopEditor.fadeout:GetText()));
+		if scriptData.args[3] == 0 then
+			scriptData.args[3] = nil;
+		end
 	end
 end
 
@@ -1164,6 +1176,10 @@ local function sound_id_local_stop_init()
 	SoundIDLocalStopEditor.id.title:SetText(loc.EFFECT_SOUND_ID_SELF_ID);
 	setTooltipForSameFrame(SoundIDLocalStopEditor.id.help, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_SELF_ID, loc.EFFECT_SOUND_ID_STOP_ID_TT);
 
+	-- Fadeout
+	SoundIDLocalStopEditor.fadeout.title:SetText(loc.EFFECT_SOUND_ID_FADEOUT);
+	setTooltipForSameFrame(SoundIDLocalStopEditor.id.help, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_FADEOUT, loc.EFFECT_SOUND_ID_FADEOUT_TT);
+
 	SoundIDLocalStopEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	SoundIDLocalStopEditor.play:SetScript("OnClick", function(self)
 		local soundID = tonumber(strtrim(SoundIDLocalStopEditor.id:GetText()));
@@ -1176,6 +1192,7 @@ local function sound_id_local_stop_init()
 		local data = scriptData.args or Globals.empty;
 		SoundIDLocalStopEditor.channel:SetSelectedValue(data[1] or "SFX");
 		SoundIDLocalStopEditor.id:SetText(data[2] or "");
+		SoundIDLocalStopEditor.fadeout:SetText(data[3] or "");
 	end
 
 	function SoundIDLocalStopEditor.save(scriptData)
@@ -1183,6 +1200,10 @@ local function sound_id_local_stop_init()
 		scriptData.args[2] = tonumber(strtrim(SoundIDLocalStopEditor.id:GetText()));
 		if scriptData.args[2] == 0 then
 			scriptData.args[2] = nil;
+		end
+		scriptData.args[3] = tonumber(strtrim(SoundIDLocalStopEditor.fadeout:GetText()));
+		if scriptData.args[3] == 0 then
+			scriptData.args[3] = nil;
 		end
 	end
 end

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -1176,7 +1176,7 @@ local function sound_id_local_stop_init()
 			end
 		end,
 		getDefaultArgs = function()
-			return {"SFX", nil};
+			return {"SFX", nil, nil};
 		end,
 		editor = SoundIDLocalStopEditor,
 	});

--- a/totalRP3_Extended_Tools/script/effects/effects.xml
+++ b/totalRP3_Extended_Tools/script/effects/effects.xml
@@ -363,6 +363,13 @@
 				</Anchors>
 			</Button>
 
+			<EditBox parentKey="fadeout" inherits="TRP3_TitledHelpEditBox">
+				<Size x="260" y="18"/>
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.id" x="0" y="-20"/>
+				</Anchors>
+			</EditBox>
+
 		</Frames>
 
 	</Frame>
@@ -429,6 +436,13 @@
 					<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.id" x="5" y="2"/>
 				</Anchors>
 			</Button>
+
+			<EditBox parentKey="fadeout" inherits="TRP3_TitledHelpEditBox">
+				<Size x="260" y="18"/>
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.id" x="0" y="-20"/>
+				</Anchors>
+			</EditBox>
 
 		</Frames>
 


### PR DESCRIPTION
Added a field to set a fadeout duration when stopping a sound and a local sound.
The field takes the duration in seconds.
I briefly considered it for the stop music effect but as I've not modified that function in TRP3, will have to be reevaluated at a later time.