### PR TITLE
Resolve errors with recent core changes

### DIFF
--- a/totalRP3_Extended_Tools/campaign/editor/actions.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/actions.lua
@@ -35,7 +35,7 @@ local function decorateActionLine(line, actionIndex)
 	local data = toolFrame.specificDraft;
 	local actionData = data.AC[actionIndex];
 
-	TRP3_API.ui.frame.setupIconButton(line.Icon, TRP3_API.quest.getActionTypeIcon(actionData.TY) or Globals.icons.default);
+	TRP3_API.ui.frame.setupIconButton(line.Icon, TRP3_API.quest.getActionTypeIcon(actionData.TY) or TRP3_InterfaceIcons.Default);
 	line.Name:SetText(TRP3_API.quest.getActionTypeLocale(actionData.TY or UNKNOWN));
 	if actionData.CO then
 		line.Description:SetText("|cff00ff00" .. loc.CA_ACTIONS_COND_ON);

--- a/totalRP3_Extended_Tools/campaign/editor/actions.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/actions.lua
@@ -16,7 +16,7 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 
-local Globals, Utils  = TRP3_API.globals, TRP3_API.utils;
+local Utils  = TRP3_API.utils;
 local IsControlKeyDown = IsControlKeyDown;
 local tremove, tinsert, wipe = tremove, tinsert, wipe;
 local tsize = Utils.table.size;

--- a/totalRP3_Extended_Tools/campaign/editor/normal.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/normal.lua
@@ -16,7 +16,7 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 
-local Globals, Utils, EMPTY = TRP3_API.globals, TRP3_API.utils, TRP3_API.globals.empty;
+local Utils, EMPTY = TRP3_API.utils, TRP3_API.globals.empty;
 local tostring, tonumber, tinsert, strtrim, pairs, assert, wipe = tostring, tonumber, tinsert, strtrim, pairs, assert, wipe;
 local tsize = Utils.table.size;
 local getFullID = TRP3_API.extended.getFullID;

--- a/totalRP3_Extended_Tools/campaign/editor/normal.lua
+++ b/totalRP3_Extended_Tools/campaign/editor/normal.lua
@@ -67,7 +67,7 @@ local function decorateNPCLine(line, npcID)
 	local data = toolFrame.specificDraft;
 	local npcData = data.ND[npcID];
 
-	TRP3_API.ui.frame.setupIconButton(line.Icon, npcData.IC or Globals.icons.profile_default);
+	TRP3_API.ui.frame.setupIconButton(line.Icon, npcData.IC or TRP3_InterfaceIcons.ProfileDefault);
 	line.Name:SetText(npcData.NA or loc.CA_NPC_NAME);
 	line.Description:SetText(npcData.FT or npcData.DE or "");
 	line.ID:SetText(loc.CA_NPC_ID .. ": " .. npcID);
@@ -97,7 +97,7 @@ local function newNPC(npcID)
 	npc.editor.name:SetText("");
 	npc.editor.fulltitle:SetText("");
 	npc.editor.description.scroll.text:SetText("");
-	onNPCIconSelected(Globals.icons.profile_default);
+	onNPCIconSelected(TRP3_InterfaceIcons.ProfileDefault);
 	TRP3_API.ui.frame.configureHoverFrame(npc.editor, npc.list.add, "TOP", 0, 5, false);
 end
 
@@ -110,7 +110,7 @@ local function createFrom(npcID)
 		npc.editor.name:SetText(npcData.NA or "");
 		npc.editor.fulltitle:SetText(npcData.FT or "");
 		npc.editor.description.scroll.text:SetText(npcData.DE or "");
-		onNPCIconSelected(npcData.IC or Globals.icons.profile_default);
+		onNPCIconSelected(npcData.IC or TRP3_InterfaceIcons.ProfileDefault);
 	end
 end
 
@@ -125,7 +125,7 @@ local function openNPC(npcID, frame)
 			npc.editor.name:SetText(npcData.NA or "");
 			npc.editor.fulltitle:SetText(npcData.FT or "");
 			npc.editor.description.scroll.text:SetText(npcData.DE or "");
-			onNPCIconSelected(npcData.IC or Globals.icons.profile_default);
+			onNPCIconSelected(npcData.IC or TRP3_InterfaceIcons.ProfileDefault);
 			TRP3_API.ui.frame.configureHoverFrame(npc.editor, frame, "RIGHT", 0, 5);
 		else
 			newNPC();
@@ -140,7 +140,7 @@ local function onNPCSaved()
 		NA = stEtN(strtrim(npc.editor.name:GetText())),
 		FT = stEtN(strtrim(npc.editor.fulltitle:GetText())),
 		DE = stEtN(strtrim(npc.editor.description.scroll.text:GetText())),
-		IC = npc.editor.icon.selectedIcon or Globals.icons.profile_default
+		IC = npc.editor.icon.selectedIcon or TRP3_InterfaceIcons.ProfileDefault
 	}
 	if ID then
 		local structure = toolFrame.specificDraft.ND;
@@ -174,7 +174,7 @@ local function decorateQuestLine(line, questID)
 	local data = toolFrame.specificDraft;
 	local questData = data.QE[questID];
 
-	TRP3_API.ui.frame.setupIconButton(line.Icon, questData.BA.IC or Globals.icons.default);
+	TRP3_API.ui.frame.setupIconButton(line.Icon, questData.BA.IC or TRP3_InterfaceIcons.ProfileDefault);
 	line.Name:SetText(questData.BA.NA or UNKNOWN);
 	if questData.BA.IN then
 		line.ID:SetText(questID .. "\n|cff00ff00" .. loc.QE_AUTO_REVEAL);


### PR DESCRIPTION
The reordering of Resources.xml in the file load order had a knock-on effect where it breaks the (old and deprecated) "Globals.icons" table.

Migrating to use TRP3_InterfaceIcons resolves this.