### PR TITLE
Add an API endpoint for grabbing current menuData in Extended Effects

### DIFF
--- a/totalRP3_Extended_Tools/script/normal/normal.lua
+++ b/totalRP3_Extended_Tools/script/normal/normal.lua
@@ -722,6 +722,10 @@ function editor.reloadWorkflowlist(workflowIDs)
 	return workflowListStructure;
 end
 
+function editor.getCurrentMenuData()
+	return menuData
+end
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- INIT
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*


### PR DESCRIPTION
This allows addons to grab the current menuData and patch it themselves before re-saving it using init. At the moment there appears to be not method to do this other than over-writing the menuData with the default+the third party addon's actions only, causing it to over-write / conflict if two addons want to add custom effect options.