### PR TITLE
Remove usages of applyRoundTexture

### DIFF
--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -663,7 +663,7 @@ end
 
 local function decorateContainer(containerFrame, class)
 	local icon, name = getBaseClassDataSafe(class);
-	Utils.texture.applyRoundTexture(containerFrame.Icon, "Interface\\ICONS\\" .. icon, "Interface\\ICONS\\TEMP");
+	containerFrame.Icon:SetTexture("Interface\\ICONS\\" .. icon);
 	containerFrame.Title:SetText(name);
 end
 TRP3_API.inventory.decorateContainer = decorateContainer;
@@ -875,7 +875,7 @@ local function presentLoot(loot, onLootCallback, forceLoot, checker, onDiscardCa
 		return;
 	end
 	if loot then
-		Utils.texture.applyRoundTexture(lootFrame.Icon, "Interface\\ICONS\\" .. (loot.BA.IC or "Garrison_silverchest"), "Interface\\ICONS\\TEMP");
+		lootFrame.Icon:SetTexture("Interface\\ICONS\\" .. (loot.BA.IC or "Garrison_silverchest"));
 		lootFrame.Title:SetText((loot.BA.NA or loc.LOOT));
 
 		local slotCounter = 1;

--- a/totalRP3_Extended/Inventory/Inventory.xml
+++ b/totalRP3_Extended/Inventory/Inventory.xml
@@ -144,6 +144,15 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						<Anchor  point="CENTER" relativePoint="TOPLEFT" x="27" y="-27"/>
 					</Anchors>
 				</Texture>
+				<MaskTexture parentKey="IconMask" file="Interface\CharacterFrame\TempPortraitAlphaMask" hWrapMode="CLAMPTOBLACKADDITIVE" vWrapMode="CLAMPTOBLACKADDITIVE">
+					<Anchors>
+						<Anchor point="TOPLEFT" relativeKey="$parent.Icon" x="2" y="-2"/>
+						<Anchor point="BOTTOMRIGHT" relativeKey="$parent.Icon" x="-2" y="2"/>
+					</Anchors>
+					<MaskedTextures>
+						<MaskedTexture childKey="Icon"/>
+					</MaskedTextures>
+				</MaskTexture>
 			</Layer>
 			<Layer level="BORDER" textureSubLevel="0">
 				<Texture parentKey="Top" file="Interface\ContainerFrame\UI-Bag-Components">

--- a/totalRP3_Extended/Inventory/InventoryDrop.lua
+++ b/totalRP3_Extended/Inventory/InventoryDrop.lua
@@ -229,7 +229,7 @@ end
 
 function showStash(stashInfo, stashIndex, sharedData)
 	if stashInfo then
-		Utils.texture.applyRoundTexture(stashContainer.Icon, "Interface\\ICONS\\" .. (stashInfo.BA.IC or "TEMP"), "Interface\\ICONS\\TEMP");
+		stashContainer.Icon:SetTexture("Interface\\ICONS\\" .. (stashInfo.BA.IC or "TEMP"));
 		stashContainer.Title:SetText((stashInfo.BA.NA or loc.DR_STASHES_NAME));
 
 		if not sharedData or not stashContainer.sync then


### PR DESCRIPTION
This utility is being culled; the few call sites in Extended need adjusting to use mask textures instead. Unsure if there's any texture widgets missed by this.