### PR TITLE
Update workflow links on rename/deletion

### DIFF
--- a/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
@@ -240,6 +240,7 @@ function editor.init(ToolFrame)
 		}
 	}
 	editor:SetScript("OnShow", function()
+		refreshList();
 		TRP3_ExtendedTutorial.loadStructure(TUTORIAL);
 	end);
 end

--- a/totalRP3_Extended_Tools/Cutscene/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Cutscene/Editor/Normal.lua
@@ -371,6 +371,7 @@ local function onTabChanged(tabWidget, tab) -- luacheck: ignore 212
 		main:Show();
 		loadWorkflows();
 		TRP3_ExtendedTutorial.loadStructure(TUTORIAL);
+		TRP3_ScriptEditorNormal.safeLoadList(editor.workflow, editor.workflowIDs, toolFrame.specificDraft.DS[editor.stepID].WO or "");
 	elseif currentTab == TABS.WORKFLOWS then
 		TRP3_ScriptEditorNormal:SetParent(toolFrame.cutscene.normal);
 		TRP3_ScriptEditorNormal:SetAllPoints();

--- a/totalRP3_Extended_Tools/Items/Editor/Quick.lua
+++ b/totalRP3_Extended_Tools/Items/Editor/Quick.lua
@@ -120,18 +120,6 @@ local function onQuickCreatedFromList(classID, _)
 	end, nil, 1);
 end
 
-function TRP3_API.extended.tools.replaceID(dataToUpdate, oldID, newID)
-	if type(dataToUpdate) == "table" then
-		for key, value in pairs(dataToUpdate) do
-			if type(value) == "table" then
-				TRP3_API.extended.tools.replaceID(value, oldID, newID);
-			elseif type(value) == "string" then
-				dataToUpdate[key] = value:gsub(oldID, newID);
-			end
-		end
-	end
-end
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- INIT
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3_Extended_Tools/Items/Editor/Quick.lua
+++ b/totalRP3_Extended_Tools/Items/Editor/Quick.lua
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
-local pairs, tonumber, date, strtrim = pairs, tonumber, date, strtrim;
 local getClass = TRP3_API.extended.getClass;
 local stEtN = Utils.str.emptyToNil;
 local loc = TRP3_API.loc;

--- a/totalRP3_Extended_Tools/Script/Normal/Normal.lua
+++ b/totalRP3_Extended_Tools/Script/Normal/Normal.lua
@@ -538,6 +538,104 @@ local function openWorkflow(workflowID)
 	end
 end
 
+local function deleteWorkflow(workflowID)
+	wipe(toolFrame.specificDraft.SC[workflowID]);
+	toolFrame.specificDraft.SC[workflowID] = nil;
+
+	-- Actions
+	if toolFrame.specificDraft.AC then
+		for _, action in pairs(toolFrame.specificDraft.AC) do
+			if action.SC == workflowID then
+				action.SC = nil;
+			end
+		end
+	end
+
+	-- Links
+	if toolFrame.specificDraft.LI then
+		for link, workflow in pairs(toolFrame.specificDraft.LI) do
+			if workflow == workflowID then
+				toolFrame.specificDraft.LI[link] = nil;
+			end
+		end
+	end
+
+	-- Events
+	if toolFrame.specificDraft.HA then
+		for _, event in pairs(toolFrame.specificDraft.HA) do
+			if event.SC == workflowID then
+				event.SC = nil;
+			end
+		end
+	end
+
+	-- Cutscene steps
+	if toolFrame.specificDraft.DS then
+		for _, cutsceneStep in pairs(toolFrame.specificDraft.DS) do
+			if cutsceneStep.WO == workflowID then
+				cutsceneStep.WO = nil;
+			end
+		end
+	end
+end
+
+local function renameWorkflow(workflowID, newID)
+	toolFrame.specificDraft.SC[newID] = toolFrame.specificDraft.SC[workflowID];
+	toolFrame.specificDraft.SC[workflowID] = nil;
+
+	-- Apply rename where old workflowID was used
+
+	-- Effects
+	for _, workflow in pairs(toolFrame.specificDraft.SC) do
+		for _, element in pairs(workflow.ST) do
+			if element.e then
+				for _, effect in pairs(element.e) do
+					-- Run workflow effect
+					if effect.id == "run_workflow" and effect.args[1] == "o" and effect.args[2] == workflowID then
+						effect.args[2] = newID;
+					end
+				end
+			end
+		end
+	end
+
+	-- Actions
+	if toolFrame.specificDraft.AC then
+		for _, action in pairs(toolFrame.specificDraft.AC) do
+			if action.SC == workflowID then
+				action.SC = newID;
+			end
+		end
+	end
+
+	-- Links
+	if toolFrame.specificDraft.LI then
+		for link, workflow in pairs(toolFrame.specificDraft.LI) do
+			if workflow == workflowID then
+				toolFrame.specificDraft.LI[link] = newID;
+			end
+		end
+	end
+
+	-- Events
+	if toolFrame.specificDraft.HA then
+		for _, event in pairs(toolFrame.specificDraft.HA) do
+			if event.SC == workflowID then
+				event.SC = newID;
+			end
+		end
+	end
+
+	-- Cutscene steps
+	if toolFrame.specificDraft.DS then
+		for _, cutsceneStep in pairs(toolFrame.specificDraft.DS) do
+			if cutsceneStep.WO == workflowID then
+				cutsceneStep.WO = newID;
+			end
+		end
+	end
+end
+
 local WORKFLOW_LINE_ACTION_DELETE = 1;
 local WORKFLOW_LINE_ACTION_ID = 2;
 local WORKFLOW_LINE_ACTION_COPY = 3;
@@ -550,8 +648,7 @@ local function onWorkflowLineAction(action, line)
 
 	if action == WORKFLOW_LINE_ACTION_DELETE then
 		TRP3_API.popup.showConfirmPopup(loc.WO_REMOVE_POPUP:format(workflowID), function()
-			wipe(toolFrame.specificDraft.SC[workflowID]);
-			toolFrame.specificDraft.SC[workflowID] = nil;
+			deleteWorkflow(workflowID);
 			editor.refreshWorkflowList();
 		end);
 	elseif action == WORKFLOW_LINE_ACTION_ID then
@@ -559,8 +656,7 @@ local function onWorkflowLineAction(action, line)
 			if toolFrame.specificDraft.SC[newID] then
 				Utils.message.displayMessage(loc.WO_ADD_ID_NO_AVAILABLE, 4);
 			elseif newID and newID:len() > 0 then
-				toolFrame.specificDraft.SC[newID] = toolFrame.specificDraft.SC[workflowID];
-				toolFrame.specificDraft.SC[workflowID] = nil;
+				renameWorkflow(workflowID, newID);
 				editor.refreshWorkflowList();
 			end
 		end, nil, workflowID);


### PR DESCRIPTION
For #237.

Renaming or deleting a workflow does not clean previous links to that workflow. Dropdowns would show "No link" since they couldn't find the right value to select, but the script would still try to call the workflows with the previous name.

Renaming or deleting a workflow now automatically updates links to that workflow in:
- Actions
- Event links (both object-specific and game events)
- Cutscene steps
- Run workflow effect (only when renaming)

Notably, it doesn't update in:
- Document links (parsing text to replace the workflowID while accounting for potential special characters in IDs feels like a bad time)
- Run item workflow (no way of knowing whether the workflow renamed is the one referenced in the effect)
- Run aura workflow (would need to go through the entire database, or at minima the entire creation from root)

Some UI elements required an additional update when shown to properly reflect the updated link.

As an added bonus, two functions existed to replace a creation ID, they now use a single function, with potentially improved performance.