### PR TITLE
Load selected icon in new icon browser

### DIFF
--- a/totalRP3_Extended/Inventory/InventoryDrop.lua
+++ b/totalRP3_Extended/Inventory/InventoryDrop.lua
@@ -906,7 +906,7 @@ function dropFrame.init()
 	stashEditFrame.icon:SetScript("OnClick", function()
 		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS,
 			{ parent = stashEditFrame.icon, point = "LEFT", parentPoint = "RIGHT", x = 15 },
-			{ iconHandler });
+			{ iconHandler, nil, nil, stashEditFrame.icon.selectedIcon });
 	end);
 	stashEditFrame.hidden.Text:SetText(loc.DR_STASHES_HIDE);
 	setTooltipForSameFrame(stashEditFrame.hidden, "RIGHT", 0, 5, loc.DR_STASHES_HIDE, loc.DR_STASHES_HIDE_TT);

--- a/totalRP3_Extended_Tools/Aura/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Aura/Editor/Normal.lua
@@ -326,7 +326,7 @@ function TRP3_API.extended.tools.initAuraEditorNormal(ToolFrame)
 		TRP3_AuraTooltip:Attach(display.preview);
 	end);
 	display.preview:SetScript("OnMouseUp", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected});
+		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected, nil, nil, display.preview.aura.class.BA.IC});
 	end);
 
 	gameplay.title:SetText(loc.AU_GAMEPLAY_ATT);

--- a/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
@@ -437,7 +437,7 @@ function TRP3_API.extended.tools.initCampaignEditorNormal(ToolFrame)
 	main.vignette:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 	main.vignette:SetScript("OnClick", function(self, button)
 		if button == "LeftButton" then
-			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "TOP", parentPoint = "BOTTOM"}, {onIconSelected});
+			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "TOP", parentPoint = "BOTTOM"}, {onIconSelected, nil, nil, main.vignette.selectedIcon});
 		else
 			local values = {};
 			tinsert(values, {loc.CA_IMAGE_TT});
@@ -511,7 +511,7 @@ function TRP3_API.extended.tools.initCampaignEditorNormal(ToolFrame)
 	npc.editor.fulltitle.title:SetText(loc.CA_NPC_EDITOR_TITLE);
 	npc.editor.description.title:SetText(loc.CA_NPC_EDITOR_DESC);
 	npc.editor.icon:SetScript("OnClick", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = npc.editor, point = "RIGHT", parentPoint = "LEFT"}, {onNPCIconSelected});
+		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = npc.editor, point = "RIGHT", parentPoint = "LEFT"}, {onNPCIconSelected, nil, nil, npc.editor.icon.selectedIcon});
 	end);
 	npc.editor.save:SetScript("OnClick", function(self)
 		onNPCSaved();

--- a/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
@@ -376,7 +376,7 @@ function TRP3_API.extended.tools.initQuest(ToolFrame)
 	main.preview.Name:SetText(loc.EDITOR_PREVIEW);
 	main.preview.InfoText:SetText(loc.EDITOR_ICON_SELECT);
 	main.preview:SetScript("OnClick", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected});
+		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected, nil, nil, main.preview.selectedIcon});
 	end);
 
 	-- Auto reveal

--- a/totalRP3_Extended_Tools/Items/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Items/Editor/Normal.lua
@@ -413,7 +413,7 @@ function TRP3_API.extended.tools.initItemEditorNormal(ToolFrame)
 		TRP3_ItemTooltip:Hide();
 	end);
 	display.preview:SetScript("OnClick", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected});
+		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected, nil, nil, display.preview.selectedIcon});
 	end);
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3_Extended_Tools/Items/Editor/Quick.lua
+++ b/totalRP3_Extended_Tools/Items/Editor/Quick.lua
@@ -197,7 +197,7 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 		TRP3_ItemTooltip:Hide();
 	end);
 	editor.preview:SetScript("OnClick", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = editor, point = "LEFT", parentPoint = "RIGHT"}, {onIconSelected});
+		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = editor, point = "LEFT", parentPoint = "RIGHT"}, {onIconSelected, nil, nil, editor.preview.selectedIcon});
 	end);
 
 	-- Save

--- a/totalRP3_Extended_Tools/Items/Effects.lua
+++ b/totalRP3_Extended_Tools/Items/Effects.lua
@@ -411,7 +411,7 @@ local function inv_loot_init()
 	editor.icon:SetScript("OnClick", function()
 		TRP3_API.popup.showPopup(TRP3_API.popup.ICONS,
 			{parent = editor.icon, point = "LEFT", parentPoint = "RIGHT", x = 15},
-			{iconHandler});
+			{iconHandler, nil, nil, editor.icon.selectedIcon});
 	end);
 
 	-- Loot


### PR DESCRIPTION
With the update to the icon browser, I went through all calls to it in Extended to provide the selected icon.
The change won't break old base TRP, so no need to update the required build for this.

![image](https://github.com/Total-RP/Total-RP-3-Extended/assets/17127080/d6085621-05a9-4bfd-8d64-4dbc2b14b2ae)
