### PR TITLE
Clean up all deprecated API usages

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -33,6 +33,24 @@ globals = {
 };
 
 read_globals = {
+	C_AddOns = {
+		fields = {
+			"IsAddOnLoaded",
+		},
+	},
+
+	C_CurrencyInfo = {
+		fields = {
+			"GetCoinTextureString",
+		},
+	},
+
+	C_Item = {
+		fields = {
+			"GetItemInfo",
+		},
+	},
+
 	C_Map = {
 		fields = {
 			"GetBestMapForUnit",
@@ -115,8 +133,6 @@ read_globals = {
 	"GameTooltip",
 	"GameTooltipHeader",
 	"GetAchievementInfo",
-	"GetCoinTextureString",
-	"GetItemInfo",
 	"GetMacroIndexByName",
 	"GetMouseFocus",
 	"GetNumMacros",
@@ -133,7 +149,6 @@ read_globals = {
 	"HTML_START",
 	"INTERRUPTED",
 	"INVENTORY_TOOLTIP",
-	"IsAddOnLoaded",
 	"IsAltKeyDown",
 	"IsControlKeyDown",
 	"IsModifiedClick",

--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -110,7 +110,7 @@ local function getItemTooltipLines(slotInfo, class, forceAlt)
 			else
 				value = (class.BA.VA or 0) * (slotInfo.count or 1);
 			end
-			value = GetCoinTextureString(value);
+			value = C_CurrencyInfo.GetCoinTextureString(value);
 			extension2 = extension2 .. TRP3_API.Colors.White(value);
 
 		end

--- a/totalRP3_Extended/Inventory/Inspection.lua
+++ b/totalRP3_Extended/Inventory/Inspection.lua
@@ -27,7 +27,7 @@ local function receiveResponse(response, sender)
 	if sender == inspectionFrame.current then
 		-- Weight and value
 		local weight = TRP3_API.extended.formatWeight(response.totalWeight or 0) .. Utils.str.texture("Interface\\GROUPFRAME\\UI-Group-MasterLooter", 15);
-		local formatedValue = ("%s: %s"):format(loc.INV_PAGE_TOTAL_VALUE, GetCoinTextureString(response.totalValue or 0));
+		local formatedValue = ("%s: %s"):format(loc.INV_PAGE_TOTAL_VALUE, C_CurrencyInfo.GetCoinTextureString(response.totalValue or 0));
 		inspectionFrame.Main.Model.WeightText:SetText(weight);
 		inspectionFrame.Main.Model.ValueText:SetText(formatedValue);
 		inspectionFrame.Main.Model.WeightText:Show();

--- a/totalRP3_Extended/Inventory/InventoryExchange.lua
+++ b/totalRP3_Extended/Inventory/InventoryExchange.lua
@@ -153,7 +153,7 @@ local function drawUI()
 			exchangeFrame.left.empty:Show();
 		end
 
-		exchangeFrame.left.value:SetText(GetCoinTextureString(totalValue));
+		exchangeFrame.left.value:SetText(C_CurrencyInfo.GetCoinTextureString(totalValue));
 		exchangeFrame.left.weight:SetText(Utils.str.texture("Interface\\GROUPFRAME\\UI-Group-MasterLooter", 15) .. TRP3_API.extended.formatWeight(totalWeight));
 	end
 
@@ -202,7 +202,7 @@ local function drawUI()
 			exchangeFrame.right.empty:Show();
 		end
 
-		exchangeFrame.right.value:SetText(GetCoinTextureString(totalValue));
+		exchangeFrame.right.value:SetText(C_CurrencyInfo.GetCoinTextureString(totalValue));
 		exchangeFrame.right.weight:SetText(Utils.str.texture("Interface\\GROUPFRAME\\UI-Group-MasterLooter", 15) .. TRP3_API.extended.formatWeight(totalWeight));
 
 		exchangeFrame.ok:Enable();

--- a/totalRP3_Extended/Inventory/InventoryPage.lua
+++ b/totalRP3_Extended/Inventory/InventoryPage.lua
@@ -242,7 +242,7 @@ local function containerFrameUpdate(self)
 	-- Weight and value
 	local current = self.info.totalWeight or 0;
 	local weight = TRP3_API.extended.formatWeight(current) .. Utils.str.texture("Interface\\GROUPFRAME\\UI-Group-MasterLooter", 15);
-	local formatedValue = ("%s: %s"):format(loc.INV_PAGE_TOTAL_VALUE, GetCoinTextureString(self.info.totalValue or 0));
+	local formatedValue = ("%s: %s"):format(loc.INV_PAGE_TOTAL_VALUE, C_CurrencyInfo.GetCoinTextureString(self.info.totalValue or 0));
 	inventoryModel.WeightText:SetText(weight);
 	inventoryModel.ValueText:SetText(formatedValue);
 end

--- a/totalRP3_Extended_Tools/List/List.lua
+++ b/totalRP3_Extended_Tools/List/List.lua
@@ -849,7 +849,7 @@ function TRP3_API.extended.tools.initList(toolFrame)
 	end
 
 	-- Detect import/export module
-	hasImportExportModule = IsAddOnLoaded("totalRP3_Extended_ImpExport");
+	hasImportExportModule = C_AddOns.IsAddOnLoaded("totalRP3_Extended_ImpExport");
 	if hasImportExportModule then
 		if not TRP3_Extended_ImpExport then
 			TRP3_Extended_ImpExport = {};

--- a/totalRP3_Extended_Tools/Script/Effects/Effects.lua
+++ b/totalRP3_Extended_Tools/Script/Effects/Effects.lua
@@ -126,7 +126,7 @@ local function macro_init()
 		return self.spellName
 	end)
 	hookLinkInsert("HandleModifiedItemClick", function(link)
-		return GetItemInfo(link)
+		return C_Item.GetItemInfo(link)
 	end)
 
 	TRP3_API.RegisterCallback(TRP3_API.GameEvents, "ADDON_LOADED", function(_, name)
@@ -142,7 +142,7 @@ local function macro_init()
 				return GetSpellInfo(self:GetParent().spellID)
 			end)
 			hookLinkInsert("ToySpellButton_OnModifiedClick", function(self)
-				return GetItemInfo(C_ToyBox.GetToyLink(self.itemID))
+				return C_Item.GetItemInfo(C_ToyBox.GetToyLink(self.itemID))
 			end)
 		end
 	end)

--- a/totalRP3_Extended_Tools/Script/Element/Element.lua
+++ b/totalRP3_Extended_Tools/Script/Element/Element.lua
@@ -140,7 +140,7 @@ local function decorateBrowserLine(frame, index)
 			local argsStructure = {object = {id = objectID}};
 			text = text .. "\n" .. TRP3_API.Colors.Yellow("\"" .. TRP3_API.script.parseArgs(base.DE .. "\"", argsStructure));
 		end
-		text = text .. "\n" .. TRP3_API.Colors.White(TRP3_API.extended.formatWeight(base.WE or 0) .. " - " .. GetCoinTextureString(base.VA or 0));
+		text = text .. "\n" .. TRP3_API.Colors.White(TRP3_API.extended.formatWeight(base.WE or 0) .. " - " .. C_CurrencyInfo.GetCoinTextureString(base.VA or 0));
 
 	end
 


### PR DESCRIPTION
These functions will be killed off in 11.0. All are simple find/replace jobs, even C_Item.GetItemInfo which continues to return fifty individual values rather than a structured table.