### PR TITLE
Fix object browser after music browser rework

### DIFF
--- a/totalRP3_Extended_Tools/Script/Element/Element.lua
+++ b/totalRP3_Extended_Tools/Script/Element/Element.lua
@@ -209,7 +209,7 @@ function objectBrowser.init()
 
 	-- Create lines
 	for line = 0, 8 do
-		local button = CreateFrame("Button", "TRP3_ObjectBrowserButton_" .. line, objectBrowser.content, "TRP3_MusicBrowserLine");
+		local button = CreateFrame("Button", "TRP3_ObjectBrowserButton_" .. line, objectBrowser.content, "TRP3_ObjectBrowserLine");
 		button:SetPoint("TOP", objectBrowser.content, "TOP", 0, -10 + (line * (-31)));
 		button:SetScript("OnClick", onBrowserLineClick);
 		tinsert(objectBrowser.widgetTab, button);

--- a/totalRP3_Extended_Tools/Script/Element/Element.xml
+++ b/totalRP3_Extended_Tools/Script/Element/Element.xml
@@ -14,6 +14,56 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Button>
 
+	<!-- Object browser line  -->
+	<Button name="TRP3_ObjectBrowserLine" virtual="true" inherits="TRP3_TooltipBackdropTemplate">
+		<Size x="0" y="28"/>
+		<KeyValues>
+			<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+		</KeyValues>
+		<Anchors>
+			<Anchor point="LEFT" x="8" y="0"/>
+			<Anchor point="RIGHT" x="-25" y="0"/>
+		</Anchors>
+		<Layers>
+			<Layer level="OVERLAY">
+				<FontString name="$parentText" text="[placeholder_line]" inherits="GameFontNormal" justifyH="LEFT">
+					<Size x="0" y="10"/>
+					<Anchors>
+						<Anchor point="LEFT" x="15" y="0"/>
+						<Anchor point="RIGHT" x="-15" y="0"/>
+					</Anchors>
+					<Color b="0.95" r="0.95" g="0.95"/>
+				</FontString>
+			</Layer>
+		</Layers>
+		<Frames>
+			<Frame name="$parentHighlight" inherits="GlowBorderTemplate" hidden="true">
+				<Anchors>
+					<Anchor point="TOPLEFT" x="0" y="0"/>
+					<Anchor point="BOTTOMRIGHT" x="0" y="0"/>
+				</Anchors>
+				<Scripts>
+					<OnLoad>
+						self:SetAlpha(0.35);
+					</OnLoad>
+				</Scripts>
+			</Frame>
+		</Frames>
+		<Scripts>
+			<OnLoad inherit="prepend">
+				self:RegisterForClicks("LeftButtonUp", "RightButtonUp");
+			</OnLoad>
+			<OnEnter>
+				TRP3_RefreshTooltipForFrame(self);
+				_G[self:GetName().."Highlight"]:Show();
+			</OnEnter>
+			<OnLeave>
+				TRP3_MainTooltip:Hide();
+				_G[self:GetName().."Highlight"]:Hide();
+			</OnLeave>
+		</Scripts>
+	</Button>
+
 	<Frame name="TRP3_ScriptEditorDelay" hidden="true" inherits="TRP3_EditorEffectTemplate">
 
 		<Size x="400" y="290"/>
@@ -57,7 +107,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	</Frame>
 
-	<!-- Icon browser  -->
+	<!-- Object browser  -->
 	<Frame name="TRP3_ObjectBrowser" hidden="true" enableMouse="true" inherits="TRP3_BrowserDialogBackdropTemplate">
 		<KeyValues>
 			<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>


### PR DESCRIPTION
I have no idea why the object browser decided to inherit its line template from the music browser, and at this point I'm too afraid to ask. Just copied the old music browser line template straight into Extended and renamed it, until such a time when we redo that browser to be better.