### PR TITLE
Objective tracker fixes

### DIFF
--- a/totalRP3_Extended/Quest/Quest.xml
+++ b/totalRP3_Extended/Quest/Quest.xml
@@ -20,7 +20,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<HighlightTexture alphaMode="ADD" file="Interface/BUTTONS/ButtonHilight-Square"/>
 	</Button>
 
-	<Frame name="TRP3_QuestObjectives" hidden="true">
+	<Frame name="TRP3_QuestObjectives" parent="UIParent" hidden="true">
 		<Size x="0" y="100"/>
 		<Frames>
 			<Frame parentKey="Actions" inherits="TRP3_TooltipBackdropTemplate">

--- a/totalRP3_Extended/Quest/QuestObjective.lua
+++ b/totalRP3_Extended/Quest/QuestObjective.lua
@@ -159,11 +159,22 @@ function frame.init()
 	C_Timer.NewTicker(0.5, function()
 		frame:Hide();
 		if ObjectiveTrackerFrame:IsShown() then
-			frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice, "BOTTOMRIGHT", 0, -10);
-			frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice, "BOTTOMLEFT", 0, -10);
-			frame.Tracker:SetWidth(ObjectiveTrackerFrame.NineSlice:GetWidth());
-			display();
-			frame:Show();
+			if ObjectiveTrackerFrame:IsCollapsed() then
+				-- If tracker collapsed, we place ours below the header
+				frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.Header.Background, "BOTTOMRIGHT", 0, -10);
+				frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.Header.Background, "BOTTOMLEFT", 0, -10);
+			else
+				-- If tracker not collapsed, we place ours below the full tracker
+				frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice, "BOTTOMRIGHT", 0, -10);
+				frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice, "BOTTOMLEFT", 0, -10);
+			end
+		else
+			-- If tracker hidden, we place ours where the tracker would be
+			frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice);
+			frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice);
 		end
+		frame.Tracker:SetWidth(ObjectiveTrackerFrame.NineSlice:GetWidth());
+		display();
+		frame:Show();
 	end);
 end


### PR DESCRIPTION
- The objective tracker has been parented to UIParent to respect the UI scale.
- The position of the tracker has been fixed depending on the different tracker toggle states:
  - If the tracker is collapsed, the header is used as reference.
  - If the tracker is hidden, we use the top anchors instead of the bottom ones

| Tracker shown | Tracker collapsed | Tracker hidden (no tracking) |
|  :----:   |  :----:   |  :----:   |
| ![image](https://github.com/user-attachments/assets/9cffbc07-3cd2-4ac2-a728-799081c3a199) | ![image](https://github.com/user-attachments/assets/aafb4ea5-5823-4f2e-a149-edc43610df7d) | ![image](https://github.com/user-attachments/assets/f226fcfd-09e1-4295-a733-30953fe884d3) |