### PR TITLE
Cast delay improvements

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -189,6 +189,7 @@ read_globals = {
 	"nop",
 	"ObjectiveTrackerFrame",
 	"PickupMacro",
+	"PlayerCastingBarFrame",
 	"PROFESSIONS_USED_IN_COOKING",
 	"QUEST_LOG",
 	"QUEST_OBJECTIVES",

--- a/totalRP3_Extended/Inventory/InventoryDrop.lua
+++ b/totalRP3_Extended/Inventory/InventoryDrop.lua
@@ -684,7 +684,7 @@ local function startStashesRequest()
 		stashFoundFrame:Hide();
 		stashEditFrame:Hide();
 		wipe(stashResponse);
-		local cID = TRP3_API.extended.showCastingBar(STASHES_REQUEST_DURATION, 2, nil, nil, loc.DR_STASHES_SCAN);
+		local cID = TRP3_API.extended.showCastingBar(STASHES_REQUEST_DURATION, 2, nil, nil, loc.DR_STASHES_SCAN, false);
 		broadcast.broadcast(SEARCH_STASHES_COMMAND, TRP3_API.BroadcastMethod.World, mapID, posY, posX, cID);
 		C_Timer.After(STASHES_REQUEST_DURATION, function()
 			if TRP3_CastingBarFrame.castID == cID then

--- a/totalRP3_Extended/Misc/Cast.lua
+++ b/totalRP3_Extended/Misc/Cast.lua
@@ -97,6 +97,7 @@ end
 
 local function onUpdate(self, elapsed)
 	if ( self.casting ) then
+		frame:UpdateCastTimeText();
 		self.value = self.value + elapsed;
 		if ( self.value >= self.maxValue ) then
 			self:SetValue(self.maxValue);

--- a/totalRP3_Extended/Misc/Cast.lua
+++ b/totalRP3_Extended/Misc/Cast.lua
@@ -36,7 +36,7 @@ local function interrupt()
 	end
 end
 
-function TRP3_API.extended.showCastingBar(duration, interruptMode, class, soundID, castText)
+function TRP3_API.extended.showCastingBar(duration, interruptMode, class, soundID, castText, isSoundFileID)
 	if GetUnitSpeed("player") > 0 and interruptMode == 2 then
 		Utils.message.displayMessage(SPELL_FAILED_MOVING, 4);
 		return;
@@ -83,8 +83,13 @@ function TRP3_API.extended.showCastingBar(duration, interruptMode, class, soundI
 
 	removeSound();
 	if soundID and soundID ~= 0 then
-		local _, handlerID = Utils.music.playSoundID(soundID, "SFX", class and class.BA.NA or "Cast");
-		frame.soundHandler = handlerID;
+		if isSoundFileID then
+			local _, handlerID = Utils.music.playSoundFileID(soundID, "SFX", class and class.BA.NA or "Cast");
+			frame.soundHandler = handlerID;
+		else
+			local _, handlerID = Utils.music.playSoundID(soundID, "SFX", class and class.BA.NA or "Cast");
+			frame.soundHandler = handlerID;
+		end
 	end
 
 	return frame.castID;

--- a/totalRP3_Extended/Misc/Cast.lua
+++ b/totalRP3_Extended/Misc/Cast.lua
@@ -52,6 +52,8 @@ function TRP3_API.extended.showCastingBar(duration, interruptMode, class, soundI
 
 	frame:ClearStages();
 
+	frame:SetAllPoints(PlayerCastingBarFrame);
+
 	frame:ShowSpark();
 
 	frame.castID = Utils.str.id();

--- a/totalRP3_Extended/Quest/Quest.xml
+++ b/totalRP3_Extended/Quest/Quest.xml
@@ -20,7 +20,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<HighlightTexture alphaMode="ADD" file="Interface/BUTTONS/ButtonHilight-Square"/>
 	</Button>
 
-	<Frame name="TRP3_QuestObjectives" hidden="true">
+	<Frame name="TRP3_QuestObjectives" parent="UIParent" hidden="true">
 		<Size x="0" y="100"/>
 		<Frames>
 			<Frame parentKey="Actions" inherits="TRP3_TooltipBackdropTemplate">

--- a/totalRP3_Extended/Quest/QuestObjective.lua
+++ b/totalRP3_Extended/Quest/QuestObjective.lua
@@ -159,11 +159,22 @@ function frame.init()
 	C_Timer.NewTicker(0.5, function()
 		frame:Hide();
 		if ObjectiveTrackerFrame:IsShown() then
-			frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice, "BOTTOMRIGHT", 0, -10);
-			frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice, "BOTTOMLEFT", 0, -10);
-			frame.Tracker:SetWidth(ObjectiveTrackerFrame.NineSlice:GetWidth());
-			display();
-			frame:Show();
+			if ObjectiveTrackerFrame:IsCollapsed() then
+				-- If tracker collapsed, we place ours below the header
+				frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.Header.Background, "BOTTOMRIGHT", 0, -10);
+				frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.Header.Background, "BOTTOMLEFT", 0, -10);
+			else
+				-- If tracker not collapsed, we place ours below the full tracker
+				frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice, "BOTTOMRIGHT", 0, -10);
+				frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice, "BOTTOMLEFT", 0, -10);
+			end
+		else
+			-- If tracker hidden, we place ours where the tracker would be
+			frame:SetPoint("TOPRIGHT", ObjectiveTrackerFrame.NineSlice);
+			frame:SetPoint("TOPLEFT", ObjectiveTrackerFrame.NineSlice);
 		end
+		frame.Tracker:SetWidth(ObjectiveTrackerFrame.NineSlice:GetWidth());
+		display();
+		frame:Show();
 	end);
 end

--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -410,7 +410,7 @@ local function writeDelay(delayStructure)
 
 	if delayStructure.c == 2 then
 		-- Casting bar
-		writeLine(("castID = showCastingBar(%s, %s, args.class, %s, var(\"%s\", args))"):format(delayStructure.d, delayStructure.i or 1, delayStructure.s or 0, delayStructure.x or ""));
+		writeLine(("castID = showCastingBar(%s, %s, args.class, %s, var(\"%s\", args), %s)"):format(delayStructure.d, delayStructure.i or 1, delayStructure.s or 0, delayStructure.x or "", tostring(delayStructure.f or false)));
 		CURRENT_ENVIRONMENT["showCastingBar"] = "TRP3_API.extended.showCastingBar";
 
 		if delayStructure.i == 2 then

--- a/totalRP3_Extended_Tools/Script/Element/Element.lua
+++ b/totalRP3_Extended_Tools/Script/Element/Element.lua
@@ -28,6 +28,7 @@ end
 function delayEditor.save(scriptStepStructure)
 	scriptStepStructure.d = tonumber(delayEditor.duration:GetText()) or 1;
 	scriptStepStructure.s = tonumber(delayEditor.sound:GetText()) or 0;
+	scriptStepStructure.f = delayEditor.soundFile:GetChecked() or false;
 	scriptStepStructure.c = delayEditor.type:GetSelectedValue() or 1;
 	scriptStepStructure.i = delayEditor.interrupt:GetSelectedValue() or 1;
 	scriptStepStructure.x = stEtN(strtrim(delayEditor.text:GetText() or ""));
@@ -38,6 +39,7 @@ function delayEditor.load(scriptStepStructure)
 	delayEditor.interrupt:SetSelectedValue(scriptStepStructure.i or 1);
 	delayEditor.duration:SetText(scriptStepStructure.d or 0);
 	delayEditor.sound:SetText(scriptStepStructure.s or 0);
+	delayEditor.soundFile:SetChecked(scriptStepStructure.f or false);
 	delayEditor.text:SetText(scriptStepStructure.x or "");
 end
 
@@ -49,6 +51,10 @@ function delayEditor.init()
 	-- Cast sound
 	delayEditor.sound.title:SetText(loc.WO_DELAY_CAST_SOUND);
 	setTooltipForSameFrame(delayEditor.sound.help, "RIGHT", 0, 5, loc.WO_DELAY_CAST_SOUND, loc.WO_DELAY_CAST_SOUND_TT);
+
+	-- Cast sound file
+	delayEditor.soundFile.Text:SetText(loc.EFFECT_SOUND_ID_SELF_SOUNDFILE);
+	setTooltipForSameFrame(delayEditor.soundFile, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_SELF_SOUNDFILE, loc.EFFECT_SOUND_ID_SELF_SOUNDFILE_TT);
 
 	-- Cast text
 	delayEditor.text.title:SetText(loc.WO_DELAY_CAST_TEXT);
@@ -62,9 +68,11 @@ function delayEditor.init()
 	TRP3_API.ui.listbox.setupListBox(delayEditor.type, delayTypes, function(value)
 		if value == 2 then
 			delayEditor.sound:Show();
+			delayEditor.soundFile:Show();
 			delayEditor.text:Show();
 		else
 			delayEditor.sound:Hide();
+			delayEditor.soundFile:Hide();
 			delayEditor.text:Hide();
 		end
 	end, nil, 225, true);

--- a/totalRP3_Extended_Tools/Script/Element/Element.xml
+++ b/totalRP3_Extended_Tools/Script/Element/Element.xml
@@ -66,34 +66,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Frame name="TRP3_ScriptEditorDelay" hidden="true" inherits="TRP3_EditorEffectTemplate">
 
-		<Size x="400" y="290"/>
+		<Size x="400" y="330"/>
 
 		<Frames>
-
-			<Frame parentKey="type" inherits="TRP3_DropdownButtonTemplate" enableMouse="true" name="$parentType">
-				<Anchors>
-					<Anchor point="TOP" x="-5" y="-55"/>
-				</Anchors>
-			</Frame>
-
-			<EditBox parentKey="sound" inherits="TRP3_TitledHelpEditBox">
-				<Size x="215" y="18"/>
-				<Anchors>
-					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.type" x="4" y="-10"/>
-				</Anchors>
-			</EditBox>
-
-			<EditBox parentKey="text" inherits="TRP3_TitledHelpEditBox">
-				<Size x="215" y="18"/>
-				<Anchors>
-					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.sound" x="0" y="-20"/>
-				</Anchors>
-			</EditBox>
 
 			<EditBox parentKey="duration" inherits="TRP3_TitledHelpEditBox">
 				<Size x="215" y="18"/>
 				<Anchors>
-					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.text" x="0" y="-20"/>
+					<Anchor point="TOP" x="-5" y="-55"/>
 				</Anchors>
 			</EditBox>
 
@@ -102,6 +82,32 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.duration" x="-4" y="-15"/>
 				</Anchors>
 			</Frame>
+
+			<Frame parentKey="type" inherits="TRP3_DropdownButtonTemplate" enableMouse="true" name="$parentType">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.interrupt" x="0" y="-12"/>
+				</Anchors>
+			</Frame>
+
+			<EditBox parentKey="sound" inherits="TRP3_TitledHelpEditBox">
+				<Size x="215" y="18"/>
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.type" x="4" y="-15"/>
+				</Anchors>
+			</EditBox>
+
+			<CheckButton parentKey="soundFile" inherits="TRP3_CheckBox">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.sound" x="0" y="-15"/>
+				</Anchors>
+			</CheckButton>
+
+			<EditBox parentKey="text" inherits="TRP3_TitledHelpEditBox">
+				<Size x="215" y="18"/>
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.soundFile" x="0" y="-18"/>
+				</Anchors>
+			</EditBox>
 
 		</Frames>
 


### PR DESCRIPTION
- Added a checkbox to indicate that a sound is a sound file ID rather than a sound ID, identical to the one from the "Play sound" effect.
- Fixed some remaining issues from the 10.0 changes, namely the cast duration not updating over the duration of the cast, and the position of the castbar not matching the default castbar.