### PR TITLE
Add backgrounds browser to document editor

### DIFF
--- a/totalRP3_Extended_Tools/Document/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Document/Editor/Normal.lua
@@ -182,7 +182,6 @@ local function load()
 
 	-- Temp
 	params.title:SetText(loc.DO_PARAMS_GLOBAL);
-	params.background:SetSelectedValue(data.BCK or 8);
 	params.border:SetSelectedValue(data.BO or TRP3_API.extended.document.BorderType.PARCHMENT);
 	params.height:SetText(data.HE or "600");
 	params.width:SetText(data.WI or "450");
@@ -206,7 +205,6 @@ local function saveToDraft()
 	assert(toolFrame.specificDraft, "specificDraft is nil");
 
 	local data = toolFrame.specificDraft;
-	data.BCK = params.background:GetSelectedValue() or 8;
 	data.BO = params.border:GetSelectedValue() or TRP3_API.extended.document.BorderType.PARCHMENT;
 	data.HE = tonumber(params.height:GetText()) or 600;
 	data.WI = tonumber(params.width:GetText()) or 450;
@@ -258,8 +256,14 @@ function TRP3_API.extended.tools.initDocumentEditorNormal(ToolFrame)
 	params = toolFrame.document.normal.params;
 
 	-- Background
-	TRP3_API.ui.listbox.setupListBox(params.background, TRP3_API.ui.frame.getTiledBackgroundList(), nil, nil, 220, true);
-	params.background:SetWidth(220);
+	params.background:SetText(loc.UI_BKG_BUTTON);
+	params.background:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			toolFrame.specificDraft.BCK = imageInfo and imageInfo.id or 8;
+		end
+
+		TRP3_API.popup.showPopup(TRP3_API.popup.BACKGROUNDS, {parent = toolFrame, point = "CENTER", parentPoint = "CENTER"}, {OnBackgroundSelected, nil, nil, toolFrame.specificDraft.BCK or 8});
+	end);
 
 	-- Border
 	TRP3_API.ui.listbox.setupListBox(params.border, {

--- a/totalRP3_Extended_Tools/Document/Editor/Normal.xml
+++ b/totalRP3_Extended_Tools/Document/Editor/Normal.xml
@@ -52,16 +52,18 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 				<Frames>
 
-					<Frame parentKey="background" inherits="TRP3_DropdownButtonTemplate" enableMouse="true" name="$parentBackground">
+					<Button parentKey="background" inherits="TRP3_CommonButton" enableMouse="true" name="$parentBackground">
+					<Size y="22"/>
 						<Anchors>
-							<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.title" x="10" y="-10"/>
+							<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.title" x="10" y="-4"/>
+							<Anchor point="RIGHT" relativePoint="CENTER" x="-20" y="0"/>
 						</Anchors>
-					</Frame>
+					</Button>
 
 					<EditBox parentKey="height" inherits="TRP3_TitledHelpEditBox" numeric="true">
 						<Size x="0" y="18"/>
 						<Anchors>
-							<Anchor point="TOPLEFT" x="4" y="-10" relativePoint="BOTTOMLEFT" relativeKey="$parent.background"/>
+							<Anchor point="TOPLEFT" x="4" y="-16" relativePoint="BOTTOMLEFT" relativeKey="$parent.background"/>
 							<Anchor point="RIGHT" relativePoint="CENTER" x="-20" y="0"/>
 						</Anchors>
 					</EditBox>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/238b0e68-0e8b-4918-b24b-b6560a4c9b5a)

This adds the backgrounds browser to the document editor and doing so, fixes the issue where the dropdown has been non-functional since 11.0.0.

Unlike the main frame, this doesn't block interactions in the background. It should, and if I don't add support for that before patch release, I'll at least make a ticket to fix that behaviour.