### PR TITLE
Resolve frame movement issues on inventory page

### DIFF
--- a/totalRP3_Extended/Inventory/InventoryPage.lua
+++ b/totalRP3_Extended/Inventory/InventoryPage.lua
@@ -233,7 +233,8 @@ function onInventoryShow()
 	TRP3_ContainerInvPageSlot17:SetFrameLevel(inventoryModel.Blocker:GetFrameLevel() + 1);
 
 	-- A bit of a hack, this ensures that we get a TOPLEFT point for the marker during its MouseUp script.
-	TRP3_MainFrame:StartMoving();
+	local alwaysStartFromMouse = true;
+	TRP3_MainFrame:StartMoving(alwaysStartFromMouse);
 	TRP3_MainFrame:StopMovingOrSizing();
 end
 


### PR DESCRIPTION
Rarely when opening the inventory page the main frame would jump as part of the stupid hack that's in place to resolve a GetPoint issue.

Seemingly telling StartMoving to always behave relative to the cursor position seems to fix this. Not sure on the precise reason why.