### PR TITLE
Add Group TOC directives

### DIFF
--- a/totalRP3_Extended/totalRP3_Extended.toc
+++ b/totalRP3_Extended/totalRP3_Extended.toc
@@ -4,6 +4,7 @@
 ## Version: @project-version@
 ## Notes: Advanced features for Total RP 3|n|n|cffffd200Version:|r @project-version@
 ## IconTexture: Interface\AddOns\totalRP3_Extended\resources\extendedicon
+## Group: totalRP3
 ## OptionalDeps: WoWUnit
 ## RequiredDeps: totalRP3
 ## SavedVariables: TRP3_Tools_DB, TRP3_Exchange_DB, TRP3_Security, TRP3_Drop, TRP3_Stashes, TRP3_Extended_Flyway

--- a/totalRP3_Extended_ImpExport/totalRP3_Extended_ImpExport.toc
+++ b/totalRP3_Extended_ImpExport/totalRP3_Extended_ImpExport.toc
@@ -4,6 +4,7 @@
 ## Version: @project-version@
 ## Notes: Import/Export for Total RP 3 Extended
 ## IconTexture: 982414
+## Group: totalRP3
 ## RequiredDeps: totalRP3, totalRP3_Extended, totalRP3_Extended_Tools
 ## SavedVariables: TRP3_Extended_ImpExport
 

--- a/totalRP3_Extended_Tools/totalRP3_Extended_Tools.toc
+++ b/totalRP3_Extended_Tools/totalRP3_Extended_Tools.toc
@@ -4,6 +4,7 @@
 ## Version: @project-version@
 ## Notes: Creation tools for Total RP 3 Extended
 ## IconTexture: 982414
+## Group: totalRP3
 ## OptionalDeps: totalRP3_Extended_ImpExport
 ## RequiredDeps: totalRP3, totalRP3_Extended
 ## SavedVariables: TRP3_Tools_Parameters, TRP3_Tools_Flags


### PR DESCRIPTION
As we're grouping under the core addon, we don't need to re-specify category translations or anything and can get by with just the one directive. I've explicitly copied it into all the TOCs to prevent the auto-grouper misbehaving in weird cases that we don't yet know about.

![image](https://github.com/user-attachments/assets/22c3eabc-83fe-4583-97e4-e12f629b0953)
