### PR TITLE
Fix item drop in the world

### DIFF
--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -422,7 +422,7 @@ local ContainerDropTargetType = {
 ---@return ContainerDropTargetType?, Frame?
 local function GetContainerDropTarget()
 	local frames = GetMouseFoci();
-	
+
 	if #frames == 0 then
 		return ContainerDropTargetType.World, nil;
 	end

--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -422,6 +422,10 @@ local ContainerDropTargetType = {
 ---@return ContainerDropTargetType?, Frame?
 local function GetContainerDropTarget()
 	local frames = GetMouseFoci();
+	
+	if #frames == 0 then
+		return ContainerDropTargetType.World, nil;
+	end
 
 	for _, frame in ipairs(frames) do
 		local name = frame:GetName() or "";

--- a/totalRP3_Extended/Inventory/InventoryExchange.lua
+++ b/totalRP3_Extended/Inventory/InventoryExchange.lua
@@ -52,6 +52,9 @@ end
 local function reloadDownloads()
 	local yourData = exchangeFrame.yourData;
 	local myData = exchangeFrame.myData;
+
+	if not myData or not yourData then return end	-- Trade window was likely closed while a transfer was ongoing
+
 	for index, slot in pairs(exchangeFrame.rightSlots) do
 		slot.security:Hide();
 		slot.details:SetText("");


### PR DESCRIPTION
WorldFrame seemingly disappeared from the list of MouseFoci results as of 11.1, so the frame detection to determine if the item is getting dropped in the world wasn't working anymore. Checking if no other frame has the mouse focus should be enough to fix it, but I've kept the old code on the offchance it makes a comeback one day.

As a bonus, I found a small issue where we tried to reload the trade UI for new downloaded items but this caused a Lua error if the trade window was closed before the exchange was over.