### PR TITLE
Add Support for Player Characteristics Parsing (PS & MI Arrays)

### DIFF
--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -840,6 +840,22 @@ function TRP3_API.script.parseArgs(text, args)
 			-- Event argument
 			local index = tonumber(capture:match("event%.(%d+)") or 1) or 1;
 			return TRP3_API.extended.tools.truncateDecimals( (args.event or EMPTY)[index] or capture, decimals);
+		elseif capture:match("^player:ch:ps:") then
+			-- Player characteristics
+			local index = tonumber(capture:match("player:ch:ps:(%d+):")) or 1;
+			if capture:match(":left:text$") then
+				-- Matches "player:ch:ps:X:left:text"
+				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
+					   (TRP3_API.profile.getData("player/characteristics").PS[index].LT or capture) or capture;
+			elseif capture:match(":right:text$") then
+				-- Matches "player:ch:ps:X:right:text"
+				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
+					   (TRP3_API.profile.getData("player/characteristics").PS[index].RT or capture) or capture;
+			elseif capture:match(":value2$") then
+				-- Matches "player:ch:ps:X:value2"
+				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
+					   (TRP3_API.profile.getData("player/characteristics").PS[index].V2 or capture) or capture;
+			end				
 		else
 			-- Evaluating variable in different sources
 			local evaluatedVarValue = (args.custom or EMPTY)[capture]; -- Workflow variable

--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -840,25 +840,41 @@ function TRP3_API.script.parseArgs(text, args)
 			-- Event argument
 			local index = tonumber(capture:match("event%.(%d+)") or 1) or 1;
 			return TRP3_API.extended.tools.truncateDecimals( (args.event or EMPTY)[index] or capture, decimals);
-		elseif capture:match("^player:ch:ps:") then
+		elseif capture:match("^trp:player:ch:ps:") then
 			-- Player characteristics
 			local psData = TRP3_API.profile.getData("player/characteristics").PS or {}
-			local index = tonumber(capture:match("player:ch:ps:(%d+):")) or 1;
-			if capture:match("^player:ch:ps:max$") then
+			local index = tonumber(capture:match("trp:player:ch:ps:(%d+):")) or 1;
+			if capture:match("^trp:player:ch:ps:max$") then
 				-- Returns the highest index in the array
 				return #psData > 0 and #psData or 0;
 			end
 			if not psData[index] then return nil end
 			if capture:match(":left:text$") then
-				-- Matches "player:ch:ps:X:left:text"
+				-- Matches "trp:player:ch:ps:X:left:text"
 				return psData[index].LT or nil;
 			elseif capture:match(":right:text$") then
-				-- Matches "player:ch:ps:X:right:text"
+				-- Matches "trp:player:ch:ps:X:right:text"
 				return psData[index].RT or nil;
 			elseif capture:match(":value2$") then
-				-- Matches "player:ch:ps:X:value2"
+				-- Matches "trp:player:ch:ps:X:value2"
 				return psData[index].V2 or nil;
-			end			
+			end	
+		elseif capture:match("^trp:player:ch:mi:") then
+			-- Player profile additional information
+			local index = tonumber(capture:match("trp:player:ch:mi:(%d+)")) or 1;
+			local miData = TRP3_API.profile.getData("player/characteristics").MI or {}
+			if capture:match("^trp:player:ch:mi:max$") then
+				-- Returns the highest index in the array
+				return #miData > 0 and #miData or 0;
+			end
+			if not miData[index] then return nil end
+			if capture:match(":name$") then
+				-- Matches "trp:player:ch:mi:X:name"
+				return miData[index].NA or nil;
+			elseif capture:match(":value$") then
+				-- Matches "trp:player:ch:mi:X:value"
+				return miData[index].VA or nil;
+			end		
 		else
 			-- Evaluating variable in different sources
 			local evaluatedVarValue = (args.custom or EMPTY)[capture]; -- Workflow variable

--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -842,20 +842,23 @@ function TRP3_API.script.parseArgs(text, args)
 			return TRP3_API.extended.tools.truncateDecimals( (args.event or EMPTY)[index] or capture, decimals);
 		elseif capture:match("^player:ch:ps:") then
 			-- Player characteristics
+			local psData = TRP3_API.profile.getData("player/characteristics").PS or {}
 			local index = tonumber(capture:match("player:ch:ps:(%d+):")) or 1;
+			if capture:match("^player:ch:ps:max$") then
+				-- Returns the highest index in the array
+				return #psData > 0 and #psData or 0;
+			end
+			if not psData[index] then return nil end
 			if capture:match(":left:text$") then
 				-- Matches "player:ch:ps:X:left:text"
-				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
-					   (TRP3_API.profile.getData("player/characteristics").PS[index].LT or capture) or capture;
+				return psData[index].LT or nil;
 			elseif capture:match(":right:text$") then
 				-- Matches "player:ch:ps:X:right:text"
-				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
-					   (TRP3_API.profile.getData("player/characteristics").PS[index].RT or capture) or capture;
+				return psData[index].RT or nil;
 			elseif capture:match(":value2$") then
 				-- Matches "player:ch:ps:X:value2"
-				return (TRP3_API.profile.getData("player/characteristics").PS or {})[index] and 
-					   (TRP3_API.profile.getData("player/characteristics").PS[index].V2 or capture) or capture;
-			end				
+				return psData[index].V2 or nil;
+			end			
 		else
 			-- Evaluating variable in different sources
 			local evaluatedVarValue = (args.custom or EMPTY)[capture]; -- Workflow variable


### PR DESCRIPTION
This PR enhances the parsing logic for Total RP 3 (TRP3) extended data, handling player characteristics (PS) and miscellaneous info (MI) arrays, aligning with existing TRP3 formats.

Key Enhancements:
- Supports `trp:player:ch:ps:*:left:text`,  `trp:player:ch:ps:*:right:text` and `trp:player:ch:ps:*:value2`parsing for retrieving player characteristics attributes (eg: "Chaotic", 17)
- Supports `trp:player:ch:ps:max` to retrieve the total number of personality attributes, making it easier to check if a characteristic exists.
- Supports `trp:player:ch:mi:*:name` and `trp:player:ch:mi:*:value` parsing for accessing miscellaneous information (eg: "Voice Reference", "Someone").
- Follows TRP3's structured format (`characteristics:PS:${num}:V2`) and matches existing `trp:player:first` syntax.