### PR TITLE
Use user-defined item quality colors (11.1.5)

### DIFF
--- a/totalRP3_Extended/Inventory/InventoryUtils.lua
+++ b/totalRP3_Extended/Inventory/InventoryUtils.lua
@@ -75,22 +75,9 @@ function TRP3_API.inventory.getItemTextLine(itemClass)
 	return Utils.str.icon(icon, 25) .. " " .. name;
 end
 
-local ITEM_COLORS = {
-	[Enum.ItemQuality.Poor] = TRP3_API.ItemQualityColors.Poor,
-	[Enum.ItemQuality.Common] = TRP3_API.ItemQualityColors.Common,
-	[Enum.ItemQuality.Uncommon] = TRP3_API.ItemQualityColors.Uncommon,
-	[Enum.ItemQuality.Rare] = TRP3_API.ItemQualityColors.Rare,
-	[Enum.ItemQuality.Epic] = TRP3_API.ItemQualityColors.Epic,
-	[Enum.ItemQuality.Legendary] = TRP3_API.ItemQualityColors.Legendary,
-	[Enum.ItemQuality.Artifact] = TRP3_API.ItemQualityColors.Artifact,
-	[Enum.ItemQuality.Heirloom] = TRP3_API.ItemQualityColors.Heirloom,
-	[Enum.ItemQuality.WoWToken] = TRP3_API.ItemQualityColors.WoWToken,
-}
-local NEUTRAL_COLOR = ITEM_COLORS[Enum.ItemQuality.Common];
-
 local function getQualityColorTab(quality)
 	---@type Color
-	local color = ITEM_COLORS[quality] or NEUTRAL_COLOR;
+	local color = ColorManager.GetColorDataForItemQuality(quality) or ColorManager.GetColorDataForItemQuality(Enum.ItemQuality.Common);
 	return color:GetRGBATable();
 end
 TRP3_API.inventory.getQualityColorTab = getQualityColorTab;


### PR DESCRIPTION
Users can now define overrides for the item quality colors, so we'll use their defined colors where applicable.
Some display issues are to be expected during the session where the colors have been changed, but I can't be bothered to go update everything when a reload will do the trick.