### PR TITLE
Fix exchange/inspection options on community player list

### DIFF
--- a/totalRP3_Extended/UnitPopups.lua
+++ b/totalRP3_Extended/UnitPopups.lua
@@ -80,8 +80,9 @@ function TRP3_API.extended.unitpopups.init()
 
     local unitTypesAllowed = {
         "CHAT_ROSTER",
+        "COMMUNITIES_GUILD_MEMBER",
+        "COMMUNITIES_WOW_MEMBER",
         "FRIEND",
-        "GUILD",
         "PARTY",
         "PLAYER",
         "RAID",


### PR DESCRIPTION
Follow-up to Total-RP/Total-RP-3#1181, the options have to be adjusted for Extended's own menu entries.