### PR TITLE
Removing Extended's main frame inheritance to base TRP main frame

### DIFF
--- a/totalRP3_Extended/Main.lua
+++ b/totalRP3_Extended/Main.lua
@@ -7,6 +7,8 @@ local EMPTY = TRP3_API.globals.empty;
 local loc = TRP3_API.loc;
 local registerConfigKey = TRP3_API.configuration.registerConfigKey;
 
+local LibWindow = LibStub:GetLibrary("LibWindow-1.1");
+
 TRP3_API.extended = {
 	document = {},
 	dialog = {},
@@ -59,6 +61,159 @@ function TRP3_Extended:TriggerEvent(event, ...)
 	assert(self:IsEventValid(event), "attempted to trigger an invalid extended event");
 	self.callbacks:Fire(event, ...);
 end
+
+-- MIXINS
+
+TRP3_ToolFrameSizeConstants = {
+	DefaultWidth = 1150,
+	DefaultHeight = 730,
+	MinimumWidth = 1150,
+	MinimumHeight = 730,
+};
+
+local function ResetWindowPoint(frame)
+	local parent = frame:GetParent() or UIParent;
+	local offsetX = frame:GetLeft();
+	local offsetY = -(parent:GetTop() - frame:GetTop());
+
+	frame:ClearAllPoints();
+	frame:SetPoint("TOPLEFT", offsetX, offsetY);
+end
+
+TRP3_ToolFrameMixin = {};
+
+function TRP3_ToolFrameMixin:OnLoad()
+	tinsert(UISpecialFrames, self:GetName());
+	self.ResizeButton:Init(self);
+end
+
+function TRP3_ToolFrameMixin:OnSizeChanged()
+	self:UpdateClampRectInsets();
+	TRP3_Extended:TriggerEvent(TRP3_Extended.Events.NAVIGATION_EXTENDED_RESIZED, self:GetWidth(), self:GetHeight());
+end
+
+function TRP3_ToolFrameMixin:OnResizeStart()
+	ResetWindowPoint(self);
+end
+
+function TRP3_ToolFrameMixin:OnResizeStop(width, height)
+	self:ResizeWindow(width, height);
+end
+
+function TRP3_ToolFrameMixin:OnResizeToDefault()
+	self:RestoreWindow();
+end
+
+function TRP3_ToolFrameMixin:ResizeWindow(width, height)
+	ResetWindowPoint(self);
+	self:SetSize(width, height);
+end
+
+function TRP3_ToolFrameMixin:RestoreWindow()
+	self:SetSize(TRP3_ToolFrameSizeConstants.DefaultWidth, TRP3_ToolFrameSizeConstants.DefaultHeight);
+end
+
+function TRP3_ToolFrameMixin:UpdateClampRectInsets()
+	local width, height = self:GetSize();
+	local ratio = width / height;
+	local padding = 300;
+
+	local left = width - padding;
+	local right = -left;
+	local bottom = height - (padding / ratio);
+	local top = -bottom;
+
+	self:SetClampRectInsets(left, right, top, bottom);
+end
+
+TRP3_ToolFrameLayoutMixin = CreateFromMixins(TRP3_ToolFrameMixin);
+
+function TRP3_ToolFrameLayoutMixin:OnLoad()
+	TRP3_ToolFrameMixin.OnLoad(self);
+	self.windowLayout = nil;  -- Aliases configuration table; set during addon load.
+	TRP3_Addon.RegisterCallback(self, "WORKFLOW_ON_FINISH", "OnLayoutLoaded");
+end
+
+function TRP3_ToolFrameLayoutMixin:OnLayoutLoaded()
+	self.windowLayout = TRP3_API.configuration.getValue("window_layout_extended");
+	LibWindow.RegisterConfig(self, self.windowLayout);
+	LibWindow.MakeDraggable(self);
+	self:RestoreLayout();
+end
+
+function TRP3_ToolFrameLayoutMixin:OnSizeChanged(...)
+	if self:IsLayoutLoaded() then
+		self:SaveLayout();
+	end
+
+	TRP3_ToolFrameMixin.OnSizeChanged(self, ...);
+end
+
+function TRP3_ToolFrameLayoutMixin:IsLayoutLoaded()
+	return self.windowLayout ~= nil;
+end
+
+function TRP3_ToolFrameLayoutMixin:RestoreLayout()
+	assert(self:IsLayoutLoaded(), "attempted to restore window layout before layout has been loaded");
+
+	local width = math.max(self.windowLayout.w or TRP3_ToolFrameSizeConstants.DefaultWidth, TRP3_ToolFrameSizeConstants.MinimumWidth);
+	local height = math.max(self.windowLayout.h or TRP3_ToolFrameSizeConstants.DefaultHeight, TRP3_ToolFrameSizeConstants.MinimumHeight);
+	self:SetSize(width, height);
+	LibWindow.RestorePosition(self);
+	ResetWindowPoint(self);
+end
+
+function TRP3_ToolFrameLayoutMixin:SaveLayout()
+	assert(self:IsLayoutLoaded(), "attempted to save window layout before layout has been loaded");
+
+	local width, height = self:GetSize();
+	self.windowLayout.w = width;
+	self.windowLayout.h = height;
+	LibWindow.SavePosition(self);
+end
+
+TRP3_ToolFrameResizeButtonMixin = {};
+
+function TRP3_ToolFrameResizeButtonMixin:Init(target)
+	self.target = target;
+	self.onResizeStart = function(mouseButtonName) return self:OnResizeStart(mouseButtonName); end;
+	self.onResizeStop = function(width, height) self:OnResizeStop(width, height); end;
+	TRP3_API.ui.frame.initResize(self);
+end
+
+function TRP3_ToolFrameResizeButtonMixin:OnResizeStart(mouseButtonName)
+	if mouseButtonName == "LeftButton" then
+		self.target:OnResizeStart();
+		self:HideTooltip();
+		return false;
+	end
+
+	-- All other mouse interactions will prevent the user from resizing the
+	-- window via dragging.
+
+	if mouseButtonName == "RightButton" then
+		self.target:OnResizeToDefault();
+	end
+
+	return true;
+end
+
+function TRP3_ToolFrameResizeButtonMixin:OnResizeStop(width, height)
+	self.target:OnResizeStop(width, height);
+end
+
+function TRP3_ToolFrameResizeButtonMixin:OnTooltipShow(description)
+	description:AddTitleLine(loc.CM_RESIZE);
+	description:AddInstructionLine("DRAGDROP", loc.CM_RESIZE_TT);
+	description:AddInstructionLine("RCLICK", loc.CM_RESIZE_RESET_TT);
+end
+
+TRP3_ToolFrameCloseButtonMixin = {};
+
+function TRP3_ToolFrameCloseButtonMixin:OnClick()
+	self:GetParent():Hide();
+end
+
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- GLOBAL DB
@@ -327,7 +482,6 @@ local function initConfig()
 	registerConfigKey(TRP3_API.extended.CONFIG_NPC_HIDE_ORIGINAL, true);
 	registerConfigKey(TRP3_API.extended.CONFIG_NPC_EMBED_ORIGINAL, false);
 
-
 	-- Build configuration page
 	local CONFIG_STRUCTURE = {
 		id = "main_config_extended",
@@ -522,6 +676,8 @@ local function onInit()
 			TRP3_API.navigation.menu.selectMenu("main_14_player_quest");
 		end,
 	});
+	
+	registerConfigKey("window_layout_extended", {});
 end
 
 local function onStart()

--- a/totalRP3_Extended/Main.lua
+++ b/totalRP3_Extended/Main.lua
@@ -676,7 +676,7 @@ local function onInit()
 			TRP3_API.navigation.menu.selectMenu("main_14_player_quest");
 		end,
 	});
-	
+
 	registerConfigKey("window_layout_extended", {});
 end
 

--- a/totalRP3_Extended_Tools/Main.lua
+++ b/totalRP3_Extended_Tools/Main.lua
@@ -438,34 +438,6 @@ local function onStart()
 	PAGE_BY_TYPE[TRP3_DB.types.DIALOG].loc = loc.TYPE_DIALOG;
 	PAGE_BY_TYPE[TRP3_DB.types.AURA].loc = loc.TYPE_AURA;
 
-	toolFrame.Close:SetScript("OnClick", function(self) self:GetParent():Hide(); end);
-
-	toolFrame.Resize.minWidth = 1150;
-	toolFrame.Resize.minHeight = 730;
-	toolFrame:SetSize(toolFrame.Resize.minWidth, toolFrame.Resize.minHeight);
-	toolFrame.Resize.resizableFrame = toolFrame;
-	toolFrame.Resize.onResizeStop = function()
-		toolFrame.Minimize:Hide();
-		toolFrame.Maximize:Show();
-		TRP3_Extended:TriggerEvent(TRP3_Extended.Events.NAVIGATION_EXTENDED_RESIZED, toolFrame:GetWidth(), toolFrame:GetHeight());
-	end;
-
-	toolFrame.Maximize:SetScript("OnClick", function()
-		toolFrame.Maximize:Hide();
-		toolFrame.Minimize:Show();
-		toolFrame:SetSize(UIParent:GetWidth(), UIParent:GetHeight());
-		after(0.1, function()
-			TRP3_Extended:TriggerEvent(TRP3_Extended.Events.NAVIGATION_EXTENDED_RESIZED, toolFrame:GetWidth(), toolFrame:GetHeight());
-		end);
-	end);
-
-	toolFrame.Minimize:SetScript("OnClick", function()
-		toolFrame:SetSize(toolFrame.Resize.minWidth, toolFrame.Resize.minHeight);
-		after(0.1, function()
-			toolFrame.Resize.onResizeStop();
-		end);
-	end);
-
 	-- Root panel locale selection
 	local template = "|T%s:11:16|t";
 	local types = {

--- a/totalRP3_Extended_Tools/Main.lua
+++ b/totalRP3_Extended_Tools/Main.lua
@@ -5,7 +5,6 @@ local Globals, Events, Utils = TRP3_API.globals, TRP3_Addon.Events, TRP3_API.uti
 local pairs, assert, tostring, strsplit, wipe, date = pairs, assert, tostring, strsplit, wipe, date;
 local EMPTY = TRP3_API.globals.empty;
 local loc = TRP3_API.loc;
-local after  = C_Timer.After;
 local getFullID, getClass = TRP3_API.extended.getFullID, TRP3_API.extended.getClass;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
 local refreshTooltipForFrame = TRP3_RefreshTooltipForFrame;

--- a/totalRP3_Extended_Tools/Main.xml
+++ b/totalRP3_Extended_Tools/Main.xml
@@ -16,10 +16,8 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="Aura\Aura.xml"/>
 	<Include file="List\List.xml"/>
 
-	<Frame name="TRP3_ToolFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameMixin" hidden="true" movable="true">
-		<Anchors>
-			<Anchor point="CENTER" x="0" y="0"/>
-		</Anchors>
+	<Frame name="TRP3_ToolFrameArtTemplate" virtual="true">
+		<Size x="840" y="600"/>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture parentKey="BkgMain" file="Interface\ENCOUNTERJOURNAL\UI-EJ-MistsofPandaria">
@@ -47,6 +45,61 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Texture>
 			</Layer>
 		</Layers>
+		<Frames>
+			<Frame parentKey="Backdrop" inherits="TooltipBorderBackdropTemplate" setAllPoints="true">
+				<KeyValues>
+					<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_CREAMY_BROWN" type="global"/>
+				</KeyValues>
+				<Layers>
+					<Layer level="BORDER" textureSubLevel="-3">
+						<Texture parentKey="LeftWoodBorder" file="Interface\AddOns\totalRP3\Resources\UI\!ui-frame-wooden-border" vertTile="true">
+							<Size x="22"/>
+							<Anchors>
+								<Anchor point="TOPLEFT" x="4" y="-4"/>
+								<Anchor point="BOTTOMLEFT" x="4" y="4"/>
+							</Anchors>
+							<Color r="1" g="0.8" b="0.8"/>
+							<TexCoords left="0.0078125" right="0.2265625"/>
+						</Texture>
+						<Texture parentKey="RightWoodBorder" file="Interface\AddOns\totalRP3\Resources\UI\!ui-frame-wooden-border" vertTile="true">
+							<Size x="22"/>
+							<Anchors>
+								<Anchor point="TOPRIGHT" x="-4" y="-4"/>
+								<Anchor point="BOTTOMRIGHT" x="-4" y="4"/>
+							</Anchors>
+							<Color r="1" g="0.8" b="0.8"/>
+							<TexCoords left="0.2265625" right="0.0078125"/>
+						</Texture>
+					</Layer>
+					<Layer level="BORDER" textureSubLevel="-2">
+						<Texture parentKey="TopWoodBorder" file="Interface\AddOns\totalRP3\Resources\UI\_ui-frame-wooden-border" horizTile="true">
+							<Size y="22"/>
+							<Anchors>
+								<Anchor point="TOPLEFT" x="4" y="-4"/>
+								<Anchor point="TOPRIGHT" x="-4" y="-4"/>
+							</Anchors>
+							<Color r="1" g="0.8" b="0.8"/>
+							<TexCoords top="0.484375" bottom="0.921875"/>
+						</Texture>
+						<Texture parentKey="BottomWoodBorder" file="Interface\AddOns\totalRP3\Resources\UI\_ui-frame-wooden-border" horizTile="true">
+							<Size y="22"/>
+							<Anchors>
+								<Anchor point="BOTTOMLEFT" x="4" y="4"/>
+								<Anchor point="BOTTOMRIGHT" x="-4" y="4"/>
+							</Anchors>
+							<Color r="1" g="0.8" b="0.8"/>
+							<TexCoords top="0.015625" bottom="0.453125"/>
+						</Texture>
+					</Layer>
+				</Layers>
+			</Frame>
+		</Frames>
+	</Frame>
+
+	<Frame name="TRP3_ToolFrame" inherits="TRP3_ToolFrameArtTemplate" mixin="TRP3_ToolFrameLayoutMixin" toplevel="true" parent="UIParent" frameStrata="MEDIUM" enableMouse="true" clampedToScreen="true" hidden="true" movable="true">
+		<Anchors>
+			<Anchor point="CENTER" x="0" y="0"/>
+		</Anchors>
 		<Frames>
 			<Frame name="$parentNavBar" inherits="NavBarTemplate" parentKey="navBar">
 				<Size x="0" y="34"/>
@@ -249,32 +302,32 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 			</Frame>
 
+			<Button parentKey="CloseButton" inherits="TRP3_RedButtonCloseArtTemplate" mixin="TRP3_ToolFrameCloseButtonMixin">
+				<Size x="24" y="24"/>
+				<Anchors>
+					<Anchor point="TOPRIGHT" x="-1" y="-1"/>
+				</Anchors>
+				<Scripts>
+					<OnClick method="OnClick"/>
+				</Scripts>
+			</Button>
+
+			<Button parentKey="ResizeButton" inherits="TRP3_RedButtonResizeArtTemplate, TRP3_TooltipScriptTemplate" mixin="TRP3_ToolFrameResizeButtonMixin">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="minWidth" value="TRP3_ToolFrameSizeConstants.MinimumWidth" type="global"/>
+					<KeyValue key="minHeight" value="TRP3_ToolFrameSizeConstants.MinimumHeight" type="global"/>
+				</KeyValues>
+				<Anchors>
+					<Anchor point="BOTTOMRIGHT" x="-1" y="1"/>
+				</Anchors>
+			</Button>
 		</Frames>
 		<Scripts>
 			<OnLoad method="OnLoad" inherit="prepend"/>
-			<OnShow method="OnShow"/>
 			<OnSizeChanged method="OnSizeChanged"/>
 		</Scripts>
 	</Frame>
-
-	<Button parentKey="Reduce" frameStrata="HIGH" parent="UIParent" hidden="true">
-		<Size x="32" y="32"/>
-		<Anchors>
-			<Anchor point="TOPRIGHT" relativeTo="TRP3_ToolFrame" x="-36" y="4"/>
-		</Anchors>
-		<NormalTexture file="Interface\Buttons\UI-Panel-HideButton-Up"/>
-		<PushedTexture file="Interface\Buttons\UI-Panel-HideButton-Down"/>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
-		<Scripts>
-			<OnClick>
-				if TRP3_ToolFrame:IsVisible() then
-					TRP3_ToolFrame:Hide();
-				else
-					TRP3_ToolFrame:Show();
-				end
-			</OnClick>
-		</Scripts>
-	</Button>
 
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
 	<!--      Tutorial        -->


### PR DESCRIPTION
Since Total-RP/Total-RP-3#1182 is making changes to the main frame of the base addon, I went with an axe, severed the link between the two frames and basically copy-pasted everything.

Just like the base addon, the maximize button is getting removed (since it doesn't work properly anyway and nobody has complained about it). Also getting removing is a magnificent Reduce button parented to UIParent that just... vibed hidden from the world.

Adding a config key for the position/size of the frame as well, not sure why it didn't exist before. Mysteries.