### PR TITLE
Remove usages of dead table.size utility

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -225,6 +225,8 @@ read_globals = {
 	"strlen",
 	"strsplit",
 	"strtrim",
+	"TableHasAnyEntries",
+	"TableIsEmpty",
 	"TargetFrame",
 	"tContains",
 	"TextEmoteSpeechList",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -116,6 +116,7 @@ read_globals = {
 	"CheckInteractDistance",
 	"CombatLogGetCurrentEventInfo",
 	"CopyTable",
+	"CountTable",
 	"CreateFrame",
 	"CreateFramePool",
 	"CreateFromMixins",

--- a/totalRP3_Extended/Inventory/InventoryDrop.lua
+++ b/totalRP3_Extended/Inventory/InventoryDrop.lua
@@ -437,7 +437,7 @@ function TRP3_API.inventory.stashSlot(slotFrom, container, slotID)
 	end
 
 	-- You can't stash non empty containers, to avoid uncalculable data transfer
-	if TRP3_API.inventory.isContainerByClass(itemClass) and Utils.table.size(slotFrom.info.content or EMPTY) > 0 then
+	if TRP3_API.inventory.isContainerByClass(itemClass) and CountTable(slotFrom.info.content or EMPTY) > 0 then
 		if not itemClass.CO.OI then
 			Utils.message.displayMessage(loc.IT_CON_ERROR_TRADE, Utils.message.type.ALERT_MESSAGE);
 			return;
@@ -708,7 +708,7 @@ local function receivedStashesRequest(sender, mapID, posY, posX, castID)
 			local inRadius = isInRadius(MAX_SEARCH_DISTANCE, posY, posX, stash.posY or 0, stash.posX or 0);
 			if inRadius then
 				-- P2P response
-				local total = Utils.table.size(stash.item);
+				local total = CountTable(stash.item);
 				Communications.broadcast.sendP2PMessage(sender, SEARCH_STASHES_COMMAND, stash.id, stash.BA.NA, stash.BA.IC, total, castID, stash.CR);
 			end
 		end

--- a/totalRP3_Extended/Inventory/InventoryDrop.lua
+++ b/totalRP3_Extended/Inventory/InventoryDrop.lua
@@ -437,7 +437,7 @@ function TRP3_API.inventory.stashSlot(slotFrom, container, slotID)
 	end
 
 	-- You can't stash non empty containers, to avoid uncalculable data transfer
-	if TRP3_API.inventory.isContainerByClass(itemClass) and CountTable(slotFrom.info.content or EMPTY) > 0 then
+	if TRP3_API.inventory.isContainerByClass(itemClass) and TableHasAnyEntries(slotFrom.info.content or EMPTY) then
 		if not itemClass.CO.OI then
 			Utils.message.displayMessage(loc.IT_CON_ERROR_TRADE, Utils.message.type.ALERT_MESSAGE);
 			return;

--- a/totalRP3_Extended/Inventory/InventoryExchange.lua
+++ b/totalRP3_Extended/Inventory/InventoryExchange.lua
@@ -262,7 +262,7 @@ local function addToExchange(container, slotID)
 	local rootClass = getClass(rootClassID);
 
 	-- Can't exchange an non-empty bag for now
-	if TRP3_API.inventory.isContainerByClass(itemClass) and Utils.table.size(slotInfo.content or EMPTY) > 0 then
+	if TRP3_API.inventory.isContainerByClass(itemClass) and CountTable(slotInfo.content or EMPTY) > 0 then
 		if not itemClass.CO.OI then
 			Utils.message.displayMessage(loc.IT_CON_ERROR_TRADE, Utils.message.type.ALERT_MESSAGE);
 			return;

--- a/totalRP3_Extended/Inventory/InventoryExchange.lua
+++ b/totalRP3_Extended/Inventory/InventoryExchange.lua
@@ -262,7 +262,7 @@ local function addToExchange(container, slotID)
 	local rootClass = getClass(rootClassID);
 
 	-- Can't exchange an non-empty bag for now
-	if TRP3_API.inventory.isContainerByClass(itemClass) and CountTable(slotInfo.content or EMPTY) > 0 then
+	if TRP3_API.inventory.isContainerByClass(itemClass) and TableHasAnyEntries(slotInfo.content or EMPTY) then
 		if not itemClass.CO.OI then
 			Utils.message.displayMessage(loc.IT_CON_ERROR_TRADE, Utils.message.type.ALERT_MESSAGE);
 			return;

--- a/totalRP3_Extended/Inventory/InventoryMapScan/InventoryMapScanner.lua
+++ b/totalRP3_Extended/Inventory/InventoryMapScan/InventoryMapScanner.lua
@@ -145,7 +145,7 @@ broadcast.registerCommand(STASHES_SCAN_COMMAND, function(sender, mapID)
 	local stashData = TRP3_Stashes[Globals.player_realm];
 	for _, stash in pairs(stashData) do
 		if stash.uiMapID == tonumber(mapID) and not stash.BA.NS then
-			local total = TRP3_API.utils.table.size(stash.item);
+			local total = CountTable(stash.item);
 			if total > 0 then
 				broadcast.sendP2PMessage(sender, STASHES_SCAN_COMMAND, stash.mapX, stash.mapY, stash.BA.NA or loc.DR_STASHES_NAME, stash.BA.IC or "TEMP", total, stash.CR);
 			end

--- a/totalRP3_Extended/Inventory/InventoryMapScan/StashMapPin.lua
+++ b/totalRP3_Extended/Inventory/InventoryMapScan/StashMapPin.lua
@@ -50,7 +50,7 @@ function TRP3_StashMapPinMixin:GetDisplayDataFromPoiInfo(poiInfo)
 	local total = poiInfo.total;
 	-- If no total, it's a self stash, so we compute the total.
 	if not total then
-		total = Utils.table.size(poiInfo.item);
+		total = CountTable(poiInfo.item);
 	end
 	--}}}
 

--- a/totalRP3_Extended/Quest/QuestLog.lua
+++ b/totalRP3_Extended/Quest/QuestLog.lua
@@ -262,7 +262,7 @@ local function refreshQuestList(campaignID)
 		if index > 1 then
 			TRP3_QuestLogPage.Quest.Empty:Hide();
 			TRP3_QuestLogPage.Quest.scroll.child.Content.Current:Show();
-		elseif Utils.table.size(getClass(campaignID).QE) == 0 then
+		elseif CountTable(getClass(campaignID).QE) == 0 then
 			TRP3_QuestLogPage.Quest.Empty:SetText(loc.QE_CAMPAIGN_EMPTY);
 		else
 			TRP3_QuestLogPage.Quest.Empty:SetText(loc.QE_CAMPAIGN_NOQUEST);
@@ -328,7 +328,7 @@ local function refreshStepContent(campaignID, questID, questInfo)
 		html = html .. ("\n%s\n\n"):format(currentStepText);
 	end
 
-	if objectives and Utils.table.size(objectives) > 0 then
+	if objectives and CountTable(objectives) > 0 then
 		local objectivesText = "";
 		local sortedID = {};
 		for objectiveID, _ in pairs(objectives) do
@@ -354,7 +354,7 @@ local function refreshStepContent(campaignID, questID, questInfo)
 		html = html .. ("\n%s"):format(objectivesText);
 	end
 
-	if Utils.table.size(questInfo.PS or EMPTY) > 0 then
+	if CountTable(questInfo.PS or EMPTY) > 0 then
 		html = html .. ("\n{img:%s:256:32}\n"):format("Interface\\QUESTFRAME\\UI-HorizontalBreak");
 
 		local previousStepText = "";

--- a/totalRP3_Extended/Quest/QuestLog.lua
+++ b/totalRP3_Extended/Quest/QuestLog.lua
@@ -262,7 +262,7 @@ local function refreshQuestList(campaignID)
 		if index > 1 then
 			TRP3_QuestLogPage.Quest.Empty:Hide();
 			TRP3_QuestLogPage.Quest.scroll.child.Content.Current:Show();
-		elseif CountTable(getClass(campaignID).QE) == 0 then
+		elseif TableIsEmpty(getClass(campaignID).QE) then
 			TRP3_QuestLogPage.Quest.Empty:SetText(loc.QE_CAMPAIGN_EMPTY);
 		else
 			TRP3_QuestLogPage.Quest.Empty:SetText(loc.QE_CAMPAIGN_NOQUEST);
@@ -328,7 +328,7 @@ local function refreshStepContent(campaignID, questID, questInfo)
 		html = html .. ("\n%s\n\n"):format(currentStepText);
 	end
 
-	if objectives and CountTable(objectives) > 0 then
+	if objectives and TableHasAnyEntries(objectives) then
 		local objectivesText = "";
 		local sortedID = {};
 		for objectiveID, _ in pairs(objectives) do
@@ -354,7 +354,7 @@ local function refreshStepContent(campaignID, questID, questInfo)
 		html = html .. ("\n%s"):format(objectivesText);
 	end
 
-	if CountTable(questInfo.PS or EMPTY) > 0 then
+	if TableHasAnyEntries(questInfo.PS or EMPTY) then
 		html = html .. ("\n{img:%s:256:32}\n"):format("Interface\\QUESTFRAME\\UI-HorizontalBreak");
 
 		local previousStepText = "";

--- a/totalRP3_Extended/Security.lua
+++ b/totalRP3_Extended/Security.lua
@@ -1,9 +1,8 @@
 -- Copyright The Total RP 3 Extended Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local Globals, Utils, EMPTY = TRP3_API.globals, TRP3_API.utils, TRP3_API.globals.empty;
+local Globals, EMPTY = TRP3_API.globals, TRP3_API.globals.empty;
 local assert, pairs, tinsert = assert, pairs, tinsert;
-local tsize = Utils.table.size;
 local iterateObject = TRP3_API.extended.iterateObject;
 local loc = TRP3_API.loc;
 local getClass = TRP3_API.extended.getClass;
@@ -116,7 +115,7 @@ local function computeSecurity(rootObjectID, rootObject, details)
 	rootObject.securityLevel = minSecurity;
 	rootObject.details = details;
 
-	TRP3_API.Log(("Security: found %d security issues in %s (%s)."):format(Utils.table.size(details), rootObjectID, minSecurity));
+	TRP3_API.Log(("Security: found %d security issues in %s (%s)."):format(CountTable(details), rootObjectID, minSecurity));
 
 	return details;
 end
@@ -221,7 +220,7 @@ function showSecurityDetailFrame(classID, frameFrom)
 
 	securityFrame.frameFrom = frameFrom;
 	securityFrame.empty:Hide();
-	if tsize(securityFrame.securityDetails) == 0 then
+	if CountTable(securityFrame.securityDetails) == 0 then
 		securityFrame.empty:Show();
 		height = height - 50;
 	end

--- a/totalRP3_Extended/Security.lua
+++ b/totalRP3_Extended/Security.lua
@@ -220,7 +220,7 @@ function showSecurityDetailFrame(classID, frameFrom)
 
 	securityFrame.frameFrom = frameFrom;
 	securityFrame.empty:Hide();
-	if CountTable(securityFrame.securityDetails) == 0 then
+	if TableIsEmpty(securityFrame.securityDetails) then
 		securityFrame.empty:Show();
 		height = height - 50;
 	end

--- a/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
@@ -34,7 +34,7 @@ local function refreshList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(editor.list, data.AC, editor.list.slider);
 	editor.list.empty:Hide();
-	if CountTable(data.AC) == 0 then
+	if TableIsEmpty(data.AC) then
 		editor.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Actions.lua
@@ -4,7 +4,6 @@
 local Utils  = TRP3_API.utils;
 local IsControlKeyDown = IsControlKeyDown;
 local tremove, tinsert, wipe = tremove, tinsert, wipe;
-local tsize = Utils.table.size;
 local stEtN = Utils.str.emptyToNil;
 local loc = TRP3_API.loc;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
@@ -35,7 +34,7 @@ local function refreshList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(editor.list, data.AC, editor.list.slider);
 	editor.list.empty:Hide();
-	if tsize(data.AC) == 0 then
+	if CountTable(data.AC) == 0 then
 		editor.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
@@ -62,7 +62,7 @@ local function refreshNPCList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(npc.list, data.ND, npc.list.slider);
 	npc.list.empty:Hide();
-	if CountTable(data.ND) == 0 then
+	if TableIsEmpty(data.ND) then
 		npc.list.empty:Show();
 	end
 end
@@ -173,7 +173,7 @@ local function refreshQuestsList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(quests.list, data.QE or EMPTY, quests.list.slider);
 	quests.list.empty:Hide();
-	if CountTable(data.QE) == 0 then
+	if TableIsEmpty(data.QE) then
 		quests.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Normal.lua
@@ -3,7 +3,6 @@
 
 local Utils, EMPTY = TRP3_API.utils, TRP3_API.globals.empty;
 local tostring, tonumber, tinsert, strtrim, pairs, assert, wipe = tostring, tonumber, tinsert, strtrim, pairs, assert, wipe;
-local tsize = Utils.table.size;
 local getFullID = TRP3_API.extended.getFullID;
 local stEtN = Utils.str.emptyToNil;
 local loc = TRP3_API.loc;
@@ -63,7 +62,7 @@ local function refreshNPCList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(npc.list, data.ND, npc.list.slider);
 	npc.list.empty:Hide();
-	if tsize(data.ND) == 0 then
+	if CountTable(data.ND) == 0 then
 		npc.list.empty:Show();
 	end
 end
@@ -174,7 +173,7 @@ local function refreshQuestsList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(quests.list, data.QE or EMPTY, quests.list.slider);
 	quests.list.empty:Hide();
-	if tsize(data.QE) == 0 then
+	if CountTable(data.QE) == 0 then
 		quests.list.empty:Show();
 	end
 end
@@ -215,7 +214,7 @@ local function createQuest()
 		else
 			Utils.message.displayMessage(loc.CA_QUEST_EXIST:format(value), 4);
 		end
-	end, nil, "quest_" .. (Utils.table.size(toolFrame.specificDraft.QE) + 1) .. "_");
+	end, nil, "quest_" .. (CountTable(toolFrame.specificDraft.QE) + 1) .. "_");
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
@@ -3,7 +3,6 @@
 
 local Utils = TRP3_API.utils;
 local tinsert, strtrim, pairs, assert, wipe = tinsert, strtrim, pairs, assert, wipe;
-local tsize = Utils.table.size;
 local getFullID = TRP3_API.extended.getFullID;
 local stEtN = Utils.str.emptyToNil;
 local loc = TRP3_API.loc;
@@ -52,7 +51,7 @@ local function refreshObjectiveList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(objectives.list, data.OB, objectives.list.slider);
 	objectives.list.empty:Hide();
-	if tsize(data.OB) == 0 then
+	if CountTable(data.OB) == 0 then
 		objectives.list.empty:Show();
 	end
 end
@@ -138,7 +137,7 @@ local function refreshQuestStepList()
 	TRP3_API.ui.list.initList(steps.list, data.ST, steps.list.slider);
 
 	steps.list.empty:Hide();
-	if tsize(data.ST) == 0 then
+	if CountTable(data.ST) == 0 then
 		steps.list.empty:Show();
 	end
 end
@@ -180,7 +179,7 @@ local function createQuestStep()
 		else
 			Utils.message.displayMessage(loc.QE_STEP_EXIST:format(value), 4);
 		end
-	end, nil, "step_" .. (Utils.table.size(toolFrame.specificDraft.ST) + 1) .. "_");
+	end, nil, "step_" .. (CountTable(toolFrame.specificDraft.ST) + 1) .. "_");
 end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Script & inner & links tabs

--- a/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
+++ b/totalRP3_Extended_Tools/Campaign/Editor/Quest.lua
@@ -51,7 +51,7 @@ local function refreshObjectiveList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(objectives.list, data.OB, objectives.list.slider);
 	objectives.list.empty:Hide();
-	if CountTable(data.OB) == 0 then
+	if TableIsEmpty(data.OB) then
 		objectives.list.empty:Show();
 	end
 end
@@ -137,7 +137,7 @@ local function refreshQuestStepList()
 	TRP3_API.ui.list.initList(steps.list, data.ST, steps.list.slider);
 
 	steps.list.empty:Hide();
-	if CountTable(data.ST) == 0 then
+	if TableIsEmpty(data.ST) then
 		steps.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/Inner/Inner.lua
+++ b/totalRP3_Extended_Tools/Inner/Inner.lua
@@ -4,7 +4,6 @@
 local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
 local CreateFrame = CreateFrame;
 local wipe, pairs, assert, tinsert = wipe, pairs, assert, tinsert;
-local tsize = Utils.table.size;
 local getFullID, getClass = TRP3_API.extended.getFullID, TRP3_API.extended.getClass;
 local getTypeLocale = TRP3_API.extended.tools.getTypeLocale;
 local loc = TRP3_API.loc;
@@ -115,7 +114,7 @@ end
 local function refresh()
 	assert(toolFrame.specificDraft.IN, "No toolFrame.specificDraft.IN for refresh.");
 	editor.browser.container.empty:Hide();
-	if tsize(toolFrame.specificDraft.IN) == 0 then
+	if CountTable(toolFrame.specificDraft.IN) == 0 then
 		editor.browser.container.empty:Show();
 	end
 	initList(

--- a/totalRP3_Extended_Tools/Inner/Inner.lua
+++ b/totalRP3_Extended_Tools/Inner/Inner.lua
@@ -114,7 +114,7 @@ end
 local function refresh()
 	assert(toolFrame.specificDraft.IN, "No toolFrame.specificDraft.IN for refresh.");
 	editor.browser.container.empty:Hide();
-	if CountTable(toolFrame.specificDraft.IN) == 0 then
+	if TableIsEmpty(toolFrame.specificDraft.IN) then
 		editor.browser.container.empty:Show();
 	end
 	initList(

--- a/totalRP3_Extended_Tools/Links/Links.lua
+++ b/totalRP3_Extended_Tools/Links/Links.lua
@@ -35,8 +35,6 @@ end
 -- GAME
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local tsize = Utils.table.size;
-
 local EVENTS_TABLE;
 local eventsList = {};
 local linesWidget = {};
@@ -122,7 +120,7 @@ local function loadAPIEventDoc()
 
 	local apiTable = APIDocumentation:GetAPITableByTypeName("system");
 	for systemIndex, system in pairs(apiTable) do
-		if (system["Events"] and issecurevariable(system, "Events") and Utils.table.size(system["Events"]) ~= 0) then
+		if (system["Events"] and issecurevariable(system, "Events") and CountTable(system["Events"]) ~= 0) then
 			EVENTS_TABLE[systemIndex + 1] = {NA = system["Name"], EV = {}, ID = system["Name"]};
 			for eventIndex, event in pairs(system["Events"]) do
 				EVENTS_TABLE[systemIndex + 1].EV[eventIndex] = {NA = event["LiteralName"], ID = system["Name"] .. " " .. event["LiteralName"]};
@@ -286,7 +284,7 @@ local function refreshList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(gameLinksEditor.list, data.HA, gameLinksEditor.list.slider);
 	gameLinksEditor.list.empty:Hide();
-	if tsize(data.HA) == 0 then
+	if CountTable(data.HA) == 0 then
 		gameLinksEditor.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/Links/Links.lua
+++ b/totalRP3_Extended_Tools/Links/Links.lua
@@ -284,7 +284,7 @@ local function refreshList()
 	local data = toolFrame.specificDraft;
 	TRP3_API.ui.list.initList(gameLinksEditor.list, data.HA, gameLinksEditor.list.slider);
 	gameLinksEditor.list.empty:Hide();
-	if CountTable(data.HA) == 0 then
+	if TableIsEmpty(data.HA) then
 		gameLinksEditor.list.empty:Show();
 	end
 end

--- a/totalRP3_Extended_Tools/List/List.lua
+++ b/totalRP3_Extended_Tools/List/List.lua
@@ -6,7 +6,6 @@ local LibDeflate = LibStub:GetLibrary("LibDeflate");
 
 local Globals, Utils, EMPTY = TRP3_API.globals, TRP3_API.utils, TRP3_API.globals.empty;
 local stEtN = Utils.str.emptyToNil;
-local tsize = Utils.table.size;
 local getClass = TRP3_API.extended.getClass;
 local getTypeLocale = TRP3_API.extended.tools.getTypeLocale;
 local loc = TRP3_API.loc;
@@ -56,13 +55,13 @@ end
 
 local function objectHasChildren(class)
 	if class then
-		if class.IN and tsize(class.IN) > 0 then
+		if class.IN and CountTable(class.IN) > 0 then
 			return true;
 		end
-		if class.TY == TRP3_DB.types.CAMPAIGN and class.QE and tsize(class.QE) > 0 then
+		if class.TY == TRP3_DB.types.CAMPAIGN and class.QE and CountTable(class.QE) > 0 then
 			return true;
 		end
-		if class.TY == TRP3_DB.types.QUEST and class.ST and tsize(class.ST) > 0 then
+		if class.TY == TRP3_DB.types.QUEST and class.ST and CountTable(class.ST) > 0 then
 			return true;
 		end
 	end

--- a/totalRP3_Extended_Tools/List/List.lua
+++ b/totalRP3_Extended_Tools/List/List.lua
@@ -55,13 +55,13 @@ end
 
 local function objectHasChildren(class)
 	if class then
-		if class.IN and CountTable(class.IN) > 0 then
+		if class.IN and TableHasAnyEntries(class.IN) then
 			return true;
 		end
-		if class.TY == TRP3_DB.types.CAMPAIGN and class.QE and CountTable(class.QE) > 0 then
+		if class.TY == TRP3_DB.types.CAMPAIGN and class.QE and TableHasAnyEntries(class.QE) then
 			return true;
 		end
-		if class.TY == TRP3_DB.types.QUEST and class.ST and CountTable(class.ST) > 0 then
+		if class.TY == TRP3_DB.types.QUEST and class.ST and TableHasAnyEntries(class.ST) then
 			return true;
 		end
 	end

--- a/totalRP3_Extended_Tools/Script/Conditions/Conditions.lua
+++ b/totalRP3_Extended_Tools/Script/Conditions/Conditions.lua
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
-local tsize, EMPTY = Utils.table.size, Globals.empty;
+local EMPTY = Globals.empty;
 local stEtN = Utils.str.emptyToNil;
 local loc = TRP3_API.loc;
 local initList = TRP3_API.ui.list.initList;
@@ -235,7 +235,7 @@ end
 local function openOperandEditor(expressionIndex)
 	local expression = editor.scriptData[expressionIndex];
 	assert(type(expression) == "table", "operand structure is not a table");
-	assert(tsize(expression) == 3, "Table expression must be in 3 parts.");
+	assert(CountTable(expression) == 3, "Table expression must be in 3 parts.");
 
 	local leftOperand = expression[1];
 	local comparator = expression[2];
@@ -381,7 +381,7 @@ local function onTestLineClick(line, button)
 end
 
 local function getExpressionText(expression)
-	assert(tsize(expression) == 3, "Table expression must be in 3 parts.");
+	assert(CountTable(expression) == 3, "Table expression must be in 3 parts.");
 	local leftOperand = expression[1];
 	local comparator = getComparatorText(expression[2]);
 	local rightOperand = expression[3];
@@ -417,7 +417,7 @@ local function decorateConditionLine(line, index)
 end
 
 function editor.getConditionPreview(scriptData)
-	local size = tsize(scriptData);
+	local size = CountTable(scriptData);
 	if size == 1 then
 		return getExpressionText(scriptData[1]);
 	else

--- a/totalRP3_Extended_Tools/Script/Normal/Normal.lua
+++ b/totalRP3_Extended_Tools/Script/Normal/Normal.lua
@@ -4,7 +4,7 @@
 local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
 local wipe, pairs, tostring, tinsert, assert, tonumber, sort = wipe, pairs, tostring, tinsert, assert, tonumber, table.sort;
 local tContains, strjoin, unpack = tContains, strjoin, unpack;
-local tsize, EMPTY = Utils.table.size, Globals.empty;
+local EMPTY = Globals.empty;
 local loc = TRP3_API.loc;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
 local setTooltipAll = TRP3_API.ui.tooltip.setTooltipAll;
@@ -405,7 +405,7 @@ end
 
 function openLastEffect()
 	local data = toolFrame.specificDraft.SC[editor.workflowID].ST;
-	local scriptStepFrame = editor.list.listElement[tsize(data)];
+	local scriptStepFrame = editor.list.listElement[CountTable(data)];
 	if scriptStepFrame then
 		onElementClick(scriptStepFrame, "LeftButton");
 	end
@@ -720,7 +720,7 @@ local function refreshWorkflowList()
 		editor.list.add:Show();
 		editor.list.sub:Show();
 		editor.list.sub.empty:Show();
-		if Utils.table.size(toolFrame.specificDraft.SC) > 0 then
+		if CountTable(toolFrame.specificDraft.SC) > 0 then
 			editor.list.sub.empty:Hide();
 		end
 
@@ -743,7 +743,7 @@ function editor.loadList(context)
 end
 
 function editor.linkElements(workflow)
-	local size = tsize(workflow.ST);
+	local size = CountTable(workflow.ST);
 	-- Make connection between elements
 	for i = 1, size, 1 do
 		local data = workflow.ST[tostring(i)];
@@ -768,7 +768,7 @@ local function onAddWorkflow()
 			refreshWorkflowList();
 			openWorkflow(newID);
 		end
-	end, nil, "workflow" .. tsize(toolFrame.specificDraft.SC) + 1);
+	end, nil, "workflow" .. CountTable(toolFrame.specificDraft.SC) + 1);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -871,7 +871,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.workflow, title = "WO_EXECUTION", text = "TU_WO_3_TEXT",
 			arrow = "DOWN", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if tsize(toolFrame.specificDraft.SC) == 0 then
+				if CountTable(toolFrame.specificDraft.SC) == 0 then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -882,7 +882,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.effect, title = "TU_WO_4", text = "TU_WO_4_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if tsize(toolFrame.specificDraft.SC) == 0 then
+				if CountTable(toolFrame.specificDraft.SC) == 0 then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -894,7 +894,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.condition, title = "TU_WO_5", text = "TU_WO_5_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if tsize(toolFrame.specificDraft.SC) == 0 then
+				if CountTable(toolFrame.specificDraft.SC) == 0 then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -906,7 +906,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.delay, title = "TU_WO_6", text = "TU_WO_6_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if tsize(toolFrame.specificDraft.SC) == 0 then
+				if CountTable(toolFrame.specificDraft.SC) == 0 then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));

--- a/totalRP3_Extended_Tools/Script/Normal/Normal.lua
+++ b/totalRP3_Extended_Tools/Script/Normal/Normal.lua
@@ -720,7 +720,7 @@ local function refreshWorkflowList()
 		editor.list.add:Show();
 		editor.list.sub:Show();
 		editor.list.sub.empty:Show();
-		if CountTable(toolFrame.specificDraft.SC) > 0 then
+		if TableHasAnyEntries(toolFrame.specificDraft.SC) then
 			editor.list.sub.empty:Hide();
 		end
 
@@ -871,7 +871,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.workflow, title = "WO_EXECUTION", text = "TU_WO_3_TEXT",
 			arrow = "DOWN", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if CountTable(toolFrame.specificDraft.SC) == 0 then
+				if TableIsEmpty(toolFrame.specificDraft.SC) then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -882,7 +882,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.effect, title = "TU_WO_4", text = "TU_WO_4_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if CountTable(toolFrame.specificDraft.SC) == 0 then
+				if TableIsEmpty(toolFrame.specificDraft.SC) then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -894,7 +894,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.condition, title = "TU_WO_5", text = "TU_WO_5_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if CountTable(toolFrame.specificDraft.SC) == 0 then
+				if TableIsEmpty(toolFrame.specificDraft.SC) then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));
@@ -906,7 +906,7 @@ editor.init = function(ToolFrame, effectMenu)
 			box = editor.element.selector.delay, title = "TU_WO_6", text = "TU_WO_6_TEXT",
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 			callback = function()
-				if CountTable(toolFrame.specificDraft.SC) == 0 then
+				if TableIsEmpty(toolFrame.specificDraft.SC) then
 					return true, loc.TU_WO_ERROR_1;
 				end
 				openWorkflow(next(toolFrame.specificDraft.SC));


### PR DESCRIPTION
There's a baseline utility in the UI that provides equivalent functionality to our table.size utility function, so use that instead.