### PR TITLE
Remove ClearAllPoints call for NPC tooltip

### DIFF
--- a/totalRP3_Extended/Quest/CampaignNPC.lua
+++ b/totalRP3_Extended/Quest/CampaignNPC.lua
@@ -127,7 +127,6 @@ local function onMouseOver()
 			if hideOriginal() then
 				GameTooltip:Hide();
 			end
-			tooltip:ClearAllPoints();
 		end
 	end
 end


### PR DESCRIPTION
Same deal as https://github.com/Total-RP/Total-RP-3/pull/1197, made the custom NPC tooltip invisible.