### PR TITLE
Fix 12.0.1 cast bar errors

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -112,10 +112,16 @@ read_globals = {
 		},
 	},
 
+	table = {
+		fields = {
+			"wipe",
+		},
+	},
+
 	string = {
 		fields = {
 			"join",
-		}
+		},
 	},
 
 	"Ambiguate",
@@ -129,6 +135,7 @@ read_globals = {
 	"CameraZoomOut",
 	"canaccessvalue",
 	"CANCEL",
+	"CAST_BAR_CAST_TIME",
 	"CASTING_BAR_ALPHA_STEP",
 	"CASTING_BAR_FLASH_STEP",
 	"CASTING_BAR_HOLD_TIME",
@@ -168,6 +175,7 @@ read_globals = {
 	"GameTooltip",
 	"GameTooltipHeader",
 	"GetAchievementInfo",
+	"GetCVar",
 	"GetGuildInfo",
 	"GetMacroIndexByName",
 	"GetMouseFoci",

--- a/totalRP3_Extended/Main.xml
+++ b/totalRP3_Extended/Main.xml
@@ -34,6 +34,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<!-- Sub-Modules -->
 	<Include file="Misc\Utils.lua"/>
+	<Include file="Misc\CastingBarFrame.xml"/>
 	<Include file="Misc\Cast.xml"/>
 	<Include file="Misc\Sounds.xml"/>
 	<Include file="Inventory\Inventory.xml"/>

--- a/totalRP3_Extended/Misc/Cast.xml
+++ b/totalRP3_Extended/Misc/Cast.xml
@@ -4,7 +4,7 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
-	<StatusBar name="TRP3_CastingBarFrame" toplevel="true" parent="UIParent" hidden="true" inherits="CastingBarFrameTemplate" frameStrata="HIGH">
+	<StatusBar name="TRP3_CastingBarFrame" toplevel="true" parent="UIParent" hidden="true" inherits="TRP3_CastingBarFrameTemplate" frameStrata="HIGH">
 		<Size x="195" y="13" />
 		<Anchors>
 			<Anchor point="BOTTOM" x="0" y="200" />

--- a/totalRP3_Extended/Misc/CastingBarFrame.lua
+++ b/totalRP3_Extended/Misc/CastingBarFrame.lua
@@ -1,0 +1,436 @@
+local CastingBarType = {
+	ApplyingCrafting = "applyingcrafting",
+	ApplyingTalents = "applyingtalents",
+	Standard = "standard",
+	Empowered = "empowered",
+	Channel = "channel",
+	Uninterruptable = "uninterruptable",
+	Interrupted = "interrupted",
+};
+
+local CastingBarTypeInfo = {
+	[CastingBarType.ApplyingCrafting] = {
+		filling = "ui-castingbar-filling-applyingcrafting",
+		full = "ui-castingbar-full-applyingcrafting",
+		glow = "ui-castingbar-full-glow-applyingcrafting",
+		sparkFx = "CraftingGlow",
+		finishAnim = "CraftingFinish",
+	},
+	[CastingBarType.ApplyingTalents] = {
+		filling = "ui-castingbar-filling-standard",
+		full = "ui-castingbar-full-standard",
+		glow = "ui-castingbar-full-glow-standard",
+		sparkFx = "StandardGlow",
+	},
+	[CastingBarType.Standard] = {
+		filling = "ui-castingbar-filling-standard",
+		full = "ui-castingbar-full-standard",
+		glow = "ui-castingbar-full-glow-standard",
+		sparkFx = "StandardGlow",
+		finishAnim = "StandardFinish",
+	},
+	[CastingBarType.Empowered] = {
+		filling = "",
+		full = "",
+		glow = "",
+	},
+	[CastingBarType.Channel] = {
+		filling = "ui-castingbar-filling-channel",
+		full = "ui-castingbar-full-channel",
+		glow = "ui-castingbar-full-glow-channel",
+		sparkFx = "ChannelShadow",
+		finishAnim = "ChannelFinish",
+	},
+	[CastingBarType.Uninterruptable] = {
+		filling = "ui-castingbar-uninterruptable",
+		full = "ui-castingbar-uninterruptable",
+		glow = "ui-castingbar-full-glow-standard",
+	},
+	[CastingBarType.Interrupted] = {
+		filling = "ui-castingbar-interrupted",
+		full = "ui-castingbar-interrupted",
+		glow = "ui-castingbar-full-glow-standard",
+	},
+};
+
+TRP3_CastingBarMixin = {};
+
+function TRP3_CastingBarMixin:OnLoad(unit, showTradeSkills, showShield)
+	self.StagePoints = {};
+	self.StagePips = {};
+	self.StageTiers = {};
+
+	self.showCastbar = true;
+	self.showIcon = true;
+
+	local point, relativeTo, relativePoint, offsetX, offsetY = self.Spark:GetPoint(1);
+	if ( point == "CENTER" ) then
+		self.Spark.offsetY = offsetY;
+	end
+end
+
+function TRP3_CastingBarMixin:GetEffectiveType(isChannel, notInterruptible, isTradeSkill, isEmpowered)
+	if isTradeSkill then
+		return CastingBarType.ApplyingCrafting;
+	end
+	if notInterruptible then
+		return CastingBarType.Uninterruptable;
+	end
+	if isChannel then
+		return CastingBarType.Channel;
+	end
+	if isEmpowered then
+		return CastingBarType.Empowered;
+	end
+	return CastingBarType.Standard;
+end
+
+function TRP3_CastingBarMixin:IsInterruptable()
+	return self.barType ~= CastingBarType.Uninterruptable;
+end
+
+function TRP3_CastingBarMixin:GetTypeInfo(barType)
+	if not barType then
+		barType = CastingBarType.Standard;
+	end
+	return CastingBarTypeInfo[barType];
+end
+
+function TRP3_CastingBarMixin:OnUpdate(elapsed)
+	if ( self.casting or self.reverseChanneling) then
+		self.value = self.value + elapsed;
+		if(self.reverseChanneling and self.NumStages > 0) then
+			self:UpdateStage();
+		end
+		if ( self.value >= self.maxValue ) then
+			self:SetValue(self.maxValue);
+			self:UpdateCastTimeText();
+			if (not self.reverseChanneling) then
+				self:FinishSpell();
+			else
+				if self.FlashLoopingAnim and not self.FlashLoopingAnim:IsPlaying() then
+					self.FlashLoopingAnim:Play();
+					self.Flash:Show();
+				end
+			end
+			self:HideSpark();
+			return;
+		end
+		self:SetValue(self.value);
+		self:UpdateCastTimeText();
+		if ( self.Flash ) then
+			self.Flash:Hide();
+		end
+	elseif ( self.channeling ) then
+		self.value = self.value - elapsed;
+		if ( self.value <= 0 ) then
+			self:FinishSpell();
+			return;
+		end
+		self:SetValue(self.value);
+		self:UpdateCastTimeText();
+		if ( self.Flash ) then
+			self.Flash:Hide();
+		end
+	end
+
+	if ( self.casting or self.reverseChanneling or self.channeling ) then
+		if ( self.Spark ) then
+			local sparkPosition = (self.value / self.maxValue) * self:GetWidth();
+			self.Spark:SetPoint("CENTER", self, "LEFT", sparkPosition, self.Spark.offsetY or 0);
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:ApplyAlpha(alpha)
+	self:SetAlpha(alpha);
+	if self.additionalFadeWidgets then
+		for widget in pairs(self.additionalFadeWidgets) do
+			widget:SetAlpha(alpha);
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:FinishSpell()
+	if self.maxValue and not self.reverseChanneling and not self.channeling then
+		self:SetValue(self.maxValue);
+		self:UpdateCastTimeText();
+	end
+	local barTypeInfo = self:GetTypeInfo(self.barType);
+	self:SetStatusBarTexture(barTypeInfo.full);
+
+	self:HideSpark();
+
+	if ( self.Flash ) then
+		self.Flash:SetAtlas(barTypeInfo.glow);
+		self.Flash:SetAlpha(0.0);
+		self.Flash:Show();
+	end
+
+	self:PlayFadeAnim();
+	self:PlayFinishAnim();
+
+	self.casting = nil;
+	self.channeling = nil;
+	self.reverseChanneling = nil;
+end
+
+function TRP3_CastingBarMixin:ShowSpark()
+	if ( self.Spark ) then
+		self.Spark:Show();
+	end
+
+	local currentBarType = self.barType;
+
+	if currentBarType == CastingBarType.Interrupted then
+		self.Spark:SetAtlas("ui-castingbar-pip-red");
+		self.Spark.offsetY = 0;
+	elseif currentBarType == CastingBarType.Empowered then
+		self.Spark:SetAtlas("ui-castingbar-empower-cursor");
+		self.Spark.offsetY = 4;
+	else
+		self.Spark:SetAtlas("ui-castingbar-pip");
+		self.Spark.offsetY = 0;
+	end
+
+	for barType, barTypeInfo in pairs(CastingBarTypeInfo) do
+		local sparkFx = barTypeInfo.sparkFx and self[barTypeInfo.sparkFx];
+		if sparkFx then
+			sparkFx:SetShown(self.playCastFX and barType == currentBarType);
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:HideSpark()
+	if ( self.Spark ) then
+		self.Spark:Hide();
+	end
+
+	for barType, barTypeInfo in pairs(CastingBarTypeInfo) do
+		local sparkFx = barTypeInfo.sparkFx and self[barTypeInfo.sparkFx];
+		if sparkFx then
+			sparkFx:Hide();
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:PlayInterruptAnims()
+	if self.HoldFadeOutAnim then
+		self.HoldFadeOutAnim:Play();
+	end
+
+	if not self.playCastFX then
+		return;
+	end
+
+	if self.InterruptShakeAnim and tonumber(GetCVar("ShakeStrengthUI")) > 0 then
+		self.InterruptShakeAnim:Play();
+	end
+	if self.InterruptGlowAnim then
+		self.InterruptGlowAnim:Play();
+	end
+	if self.InterruptSparkAnim then
+		self.InterruptSparkAnim:Play();
+	end
+end
+
+function TRP3_CastingBarMixin:StopInterruptAnims()
+	if self.HoldFadeOutAnim then
+		self.HoldFadeOutAnim:Stop();
+	end
+	if self.InterruptShakeAnim then
+		self.InterruptShakeAnim:Stop();
+	end
+	if self.InterruptGlowAnim then
+		self.InterruptGlowAnim:Stop();
+	end
+	if self.InterruptSparkAnim then
+		self.InterruptSparkAnim:Stop();
+	end
+end
+
+function TRP3_CastingBarMixin:PlayFadeAnim()
+	if self.FlashLoopingAnim then
+		self.FlashLoopingAnim:Stop();
+	end
+
+	if self.FlashAnim then
+		self.FlashAnim:Play();
+	end
+
+	if self.FadeOutAnim and self:GetAlpha() > 0 and self:IsVisible() then
+		if self.reverseChanneling and self.CurrSpellStage < self.NumStages then
+			self.HoldFadeOutAnim:Play();
+		elseif not self.isInEditMode then
+			self.FadeOutAnim:Play();
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:PlayFinishAnim()
+	if not self.playCastFX then
+		return;
+	end
+
+	local barTypeInfo = self:GetTypeInfo(self.barType);
+
+	local playFinish = not barTypeInfo.finishCondition or barTypeInfo.finishCondition(self);
+	if playFinish then
+		local finishAnim = barTypeInfo.finishAnim and self[barTypeInfo.finishAnim];
+		if finishAnim then
+			finishAnim:Play();
+		end
+	end
+
+	if self.barType == CastingBarType.Empowered then
+		for i = 1, self.CurrSpellStage do
+			local stageTier = self.StageTiers[i];
+			if stageTier and stageTier.FinishAnim then
+				stageTier.FlashAnim:Stop();
+				stageTier.FinishAnim:Play();
+			end
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:StopFinishAnims()
+	if self.FlashAnim then
+		self.FlashAnim:Stop();
+	end
+	if self.FadeOutAnim then
+		self.FadeOutAnim:Stop();
+	end
+
+	for _, barTypeInfo in pairs(CastingBarTypeInfo) do
+		local finishAnim = barTypeInfo.finishAnim and self[barTypeInfo.finishAnim];
+		if finishAnim then
+			finishAnim:Stop();
+		end
+	end
+end
+
+function TRP3_CastingBarMixin:StopAnims()
+	self:StopInterruptAnims();
+	self:StopFinishAnims();
+end
+
+function TRP3_CastingBarMixin:SetCastTimeTextShown(showCastTime)
+	self.showCastTimeSetting = showCastTime;
+	self:UpdateCastTimeTextShown();
+end
+
+function TRP3_CastingBarMixin:UpdateCastTimeTextShown()
+	if not self.CastTimeText then
+		return;
+	end
+
+	local showCastTime = self.showCastTimeSetting and (self.casting or self.channeling or self.isInEditMode);
+	self.CastTimeText:SetShown(showCastTime);
+	if showCastTime and self.isInEditMode and not self.CastTimeText.text then
+		self:UpdateCastTimeText();
+	end
+end
+
+function TRP3_CastingBarMixin:UpdateCastTimeText()
+	if not self.CastTimeText then
+		return;
+	end
+
+	local seconds = 0;
+	if self.casting or self.channeling then
+		local min, max = self:GetMinMaxValues();
+		if self.casting then
+			seconds = math.max(min, max - self:GetValue());
+		else
+			seconds = math.max(min, self:GetValue());
+		end
+	elseif self.isInEditMode then
+		seconds = 10;
+	end
+
+	local text = string.format(CAST_BAR_CAST_TIME, seconds);
+	self.CastTimeText:SetText(text);
+end
+
+function TRP3_CastingBarMixin:SetNameTextShown(showNameText)
+	if not self.Text then
+		return;
+	end
+
+	self.Text:SetShown(showNameText);
+end
+
+function TRP3_CastingBarMixin:SetIconShown(showIcon)
+	if not self.Icon then
+		return;
+	end
+
+	self.showIcon = showIcon;
+
+	self:UpdateIconShown();
+end
+
+function TRP3_CastingBarMixin:ShouldIconBeShown()
+	if not self.showIcon then
+		return false;
+	end
+
+	if self.look ~= nil and self.look ~= "UNITFRAME" then
+		return false;
+	end
+
+	if self.HideIconWhenNotInterruptible and not self:IsInterruptable() then
+		return false;
+	end
+
+	return true;
+end
+
+function TRP3_CastingBarMixin:UpdateIconShown()
+	if not self.Icon and not self.BorderShield then
+		return;
+	end
+
+	local iconShown = self:ShouldIconBeShown();
+	if self.Icon then
+		self.Icon:SetShown(iconShown);
+	end
+
+	if self.BorderShield then
+		local shieldShown = self.showShield and not self:IsInterruptable();
+		self.BorderShield:SetShown(shieldShown);
+			if self.BarBorder then
+			self.BarBorder:SetShown(not shieldShown);
+			end
+			end
+end
+
+function TRP3_CastingBarMixin:ClearStages()
+
+	if self.ChargeGlow then
+		self.ChargeGlow:SetShown(false);
+	end
+	if self.ChargeFlash then
+		self.ChargeFlash:SetAlpha(0);
+	end
+
+	for _, stagePip in pairs(self.StagePips) do
+		local maxStage = self.NumStages;
+		for i = 1, maxStage do
+			local stageAnimName = "Stage" .. i;
+			local stageAnim = stagePip[stageAnimName];
+			if stageAnim then
+				stageAnim:Stop();
+			end
+		end
+		stagePip:Hide();
+	end
+
+	for _, stageTier in pairs(self.StageTiers) do
+		stageTier:Hide();
+	end
+
+	self.NumStages = 0;
+	table.wipe(self.StagePoints);
+	table.wipe(self.StageTiers);
+end

--- a/totalRP3_Extended/Misc/CastingBarFrame.lua
+++ b/totalRP3_Extended/Misc/CastingBarFrame.lua
@@ -55,7 +55,7 @@ local CastingBarTypeInfo = {
 
 TRP3_CastingBarMixin = {};
 
-function TRP3_CastingBarMixin:OnLoad(unit, showTradeSkills, showShield)
+function TRP3_CastingBarMixin:OnLoad()
 	self.StagePoints = {};
 	self.StagePips = {};
 	self.StageTiers = {};
@@ -63,7 +63,7 @@ function TRP3_CastingBarMixin:OnLoad(unit, showTradeSkills, showShield)
 	self.showCastbar = true;
 	self.showIcon = true;
 
-	local point, relativeTo, relativePoint, offsetX, offsetY = self.Spark:GetPoint(1);
+	local point, _, _, _, offsetY = self.Spark:GetPoint(1);
 	if ( point == "CENTER" ) then
 		self.Spark.offsetY = offsetY;
 	end
@@ -206,7 +206,7 @@ function TRP3_CastingBarMixin:HideSpark()
 		self.Spark:Hide();
 	end
 
-	for barType, barTypeInfo in pairs(CastingBarTypeInfo) do
+	for _, barTypeInfo in pairs(CastingBarTypeInfo) do
 		local sparkFx = barTypeInfo.sparkFx and self[barTypeInfo.sparkFx];
 		if sparkFx then
 			sparkFx:Hide();

--- a/totalRP3_Extended/Misc/CastingBarFrame.xml
+++ b/totalRP3_Extended/Misc/CastingBarFrame.xml
@@ -1,0 +1,212 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\..\Blizzard_SharedXML\UI.xsd">
+	<Include file="CastingBarFrame.lua"/>
+	<StatusBar name="TRP3_CastingBarFrameBaseTemplate" mixin="TRP3_CastingBarMixin" drawLayer="BORDER" virtual="true">
+		<BarTexture atlas="ui-castingbar-filling-standard" useAtlasSize="true"/>
+		<Layers>
+			<Layer level="BACKGROUND" textureSubLevel="0">
+				<Texture parentKey="DropShadow" atlas="castbar_shadow_embedded" hidden="true">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="0" y="0"/>
+						<Anchor point="BOTTOMRIGHT" x="3" y="-3"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="TextBorder" atlas="ui-castingbar-textbox">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="0" y="0"/>
+						<Anchor point="BOTTOMRIGHT" x="0" y="-12"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="BACKGROUND" textureSubLevel="1">
+				<Texture parentKey="InterruptGlow" alpha="0" alphaMode="ADD" atlas="cast_interrupt_outerglow" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="ChargeGlow" hidden="true" atlas="cast_empowered_outerglow" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="0"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="BACKGROUND" textureSubLevel="2">
+				<Texture parentKey="Background" atlas="ui-castingbar-background">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="-1" y="1"/>
+						<Anchor point="BOTTOMRIGHT" x="1" y="-1"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="ARTWORK" textureSubLevel="1">
+				<Texture parentKey="EnergyGlow" alpha="0" alphaMode="ADD" atlas="Cast_Standard_GlowLine" useAtlasSize="true" scale="0.51">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="-100"/>
+					</Anchors>
+				</Texture>
+				<MaskTexture parentKey="EnergyMask" alpha="1" alphaMode="BLEND" atlas="Cast_Standard_LineTextureMask" useAtlasSize="true" vWrapMode="CLAMPTOBLACKADDITIVE" hWrapMode="CLAMPTOBLACKADDITIVE" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER"/>
+					</Anchors>
+					<MaskedTextures>
+						<MaskedTexture childKey="EnergyGlow"/>
+					</MaskedTextures>
+				</MaskTexture>
+			</Layer>
+			<Layer level="ARTWORK" textureSubLevel="4">
+				<Texture parentKey="BorderShield" atlas="ui-castingbar-shield" hidden="true">
+					<Size x="29" y="33"/>
+					<Anchors>
+						<Anchor point="TOPLEFT" x="-27" y="4"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Icon">
+					<Size x="16" y="16"/>
+					<Anchors>
+						<Anchor point="RIGHT" relativeTo="$parent" relativePoint="LEFT" x="-5" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Border" atlas="ui-castingbar-frame">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="-2" y="2"/>
+						<Anchor point="BOTTOMRIGHT" x="2" y="-2"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="ARTWORK" textureSubLevel="5">
+				<Texture parentKey="Flakes01" alphaMode="ADD" atlas="Cast_Standard_Flakes01" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="-25"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Flakes02" alphaMode="ADD" atlas="Cast_Standard_Flakes02" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="-45"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Flakes03" alphaMode="ADD" atlas="Cast_Standard_Flakes03" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="-25"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="BaseGlow" alpha="0" alphaMode="ADD" atlas="Channel_WispGlow2" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="LEFT" x="0" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="WispGlow" alpha="0" alphaMode="ADD" atlas="Cast_Channel_WispGlow" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="LEFT" x="25" y="0"/>
+					</Anchors>
+				</Texture>
+				<MaskTexture parentKey="WispMask" alpha="1" alphaMode="BLEND" atlas="Cast_Channel_WispMask" useAtlasSize="true" vWrapMode="CLAMPTOBLACKADDITIVE" hWrapMode="CLAMPTOBLACKADDITIVE" scale="0.5">
+					<Anchors>
+						<Anchor point="LEFT" x="-90" y="-2"/>
+					</Anchors>
+					<MaskedTextures>
+						<MaskedTexture childKey="WispGlow"/>
+					</MaskedTextures>
+				</MaskTexture>
+				<Texture parentKey="Sparkles01" alpha="0" alphaMode="BLEND" atlas="Cast_Channel_Sparkles_01" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="LEFT"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Sparkles02" alpha="0" alphaMode="BLEND" atlas="Cast_Channel_Sparkles_02" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="LEFT"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="OVERLAY" textureSubLevel="1">
+				<Texture parentKey="Flash" atlas="ui-castingbar-full-glow-standard" alphaMode="ADD">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="-1" y="1"/>
+						<Anchor point="BOTTOMRIGHT" x="1" y="-1"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="ChargeFlash" alpha="0" atlas="ui-castingbar-full-glow-standard" alphaMode="ADD" setAllPoints="true"/>
+				<FontString parentKey="Text" inherits="GameFontHighlightSmall">
+					<Size x="185" y="16"/>
+					<Anchors>
+						<Anchor point="TOP" x="0" y="-10"/>
+					</Anchors>
+				</FontString>
+				<FontString parentKey="CastTimeText" inherits="GameFontHighlightLarge">
+					<Anchors>
+						<Anchor point="LEFT" relativePoint="RIGHT" x="10" y="0"/>
+					</Anchors>
+				</FontString>
+			</Layer>
+			<Layer level="OVERLAY" textureSubLevel="2">
+				<Texture parentKey="Spark" atlas="ui-castingbar-pip">
+					<Size x="8" y="20"/>
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="Shine" alpha="0" alphaMode="ADD" atlas="Cast_Crafting_ShineWipe" useAtlasSize="true" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="-110"/>
+					</Anchors>
+				</Texture>
+				<MaskTexture parentKey="CraftingMask" alpha="1" alphaMode="BLEND" atlas="Cast_Crafting_LineTextureMask" useAtlasSize="true" vWrapMode="CLAMPTOBLACKADDITIVE" hWrapMode="CLAMPTOBLACKADDITIVE" scale="0.5">
+					<Anchors>
+						<Anchor point="CENTER"/>
+					</Anchors>
+					<MaskedTextures>
+						<MaskedTexture childKey="Shine"/>
+					</MaskedTextures>
+				</MaskTexture>
+			</Layer>
+			<Layer level="OVERLAY" textureSubLevel="3">
+				<Texture parentKey="StandardGlow" alpha="1" alphaMode="ADD" atlas="cast_standard_pipglow" hidden="true">
+					<Size x="37" y="12"/>
+					<Anchors>
+						<Anchor point="RIGHT" relativePoint="LEFT" relativeKey="$parent.Spark" x="2" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="CraftGlow" alpha="1" alphaMode="ADD" atlas="cast_crafting_pipglow" hidden="true">
+					<Size x="37" y="12"/>
+					<Anchors>
+						<Anchor point="RIGHT" relativePoint="LEFT" relativeKey="$parent.Spark" x="2" y="0"/>
+					</Anchors>
+				</Texture>
+				<Texture parentKey="ChannelShadow" alpha="1" alphaMode="BLEND" atlas="cast_channel_pipshadow" hidden="true">
+					<Size x="11" y="11"/>
+					<Anchors>
+						<Anchor point="RIGHT" relativePoint="LEFT" relativeKey="$parent.Spark" x="1" y="0"/>
+					</Anchors>
+				</Texture>
+				<MaskTexture parentKey="BorderMask" atlas="cast_standard_barmask" hWrapMode="CLAMPTOBLACKADDITIVE" vWrapMode="CLAMPTOBLACKADDITIVE">
+					<Size x="256" y="13"/>
+					<Anchors>
+						<Anchor point="CENTER" x="0" y="0"/>
+					</Anchors>
+					<MaskedTextures>
+						<MaskedTexture childKey="StandardGlow"/>
+						<MaskedTexture childKey="CraftGlow"/>
+						<MaskedTexture childKey="ChannelShadow"/>
+						<MaskedTexture childKey="EnergyGlow"/>
+						<MaskedTexture childKey="Flakes01"/>
+						<MaskedTexture childKey="Flakes02"/>
+						<MaskedTexture childKey="Flakes03"/>
+						<MaskedTexture childKey="Shine"/>
+						<MaskedTexture childKey="BaseGlow"/>
+						<MaskedTexture childKey="WispGlow"/>
+						<MaskedTexture childKey="Sparkles01"/>
+						<MaskedTexture childKey="Sparkles02"/>
+					</MaskedTextures>
+				</MaskTexture>
+			</Layer>
+		</Layers>
+		<Scripts>
+			<OnLoad>
+				self:OnLoad(nil, true, false);
+			</OnLoad>
+			<OnUpdate method="OnUpdate" />
+		</Scripts>
+	</StatusBar>
+
+	<StatusBar name="TRP3_CastingBarFrameTemplate" inherits="TRP3_CastingBarFrameBaseTemplate, CastingBarFrameAnimsFXTemplate" virtual="true"/>
+</Ui>

--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -542,7 +542,15 @@ end
 
 local pcall = pcall;
 local function executeFunction(func, args, scriptID)
+--@debug@
+	func(args);
+	local status = true;
+	local ret = "";
+--@end-debug@
+
+--[===[@non-debug@
 	local status, ret, _ = pcall(func, args);
+--@end-non-debug@]===]
 	if status then
 		--		if DEBUG then TRP3_API.utils.table.dump(conditions); end
 		return ret;

--- a/totalRP3_Extended/Script/ScriptGeneration.lua
+++ b/totalRP3_Extended/Script/ScriptGeneration.lua
@@ -540,7 +540,6 @@ local function getFunction(structure, rootClassID)
 	end
 end
 
-local pcall = pcall;
 local function executeFunction(func, args, scriptID)
 --@debug@
 	func(args);


### PR DESCRIPTION
Cast bar enum keys have been made secret which messes with our own castbar trying to reuse the existing template. As a workaround for now, we'll duplicate the template (with a lot of unused functions trimmed out) and inherit from that one instead.

As a bonus change, I've removed the pcall on workflow scripts in debug mode, as it's a pain in the ass.