### PR TITLE
Fix OPie bag issues + add item bypassing the player inventory limit

### DIFF
--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -423,12 +423,8 @@ local ContainerDropTargetType = {
 local function GetContainerDropTarget()
 	local frames = GetMouseFoci();
 
-	if #frames == 0 then
-		return ContainerDropTargetType.World, nil;
-	end
-
 	for _, frame in ipairs(frames) do
-		local name = frame:GetName() or "WorldFrame";
+		local name = frame:GetName() or "";
 
 		if name == "WorldFrame" then
 			return ContainerDropTargetType.World, frame;
@@ -441,7 +437,7 @@ local function GetContainerDropTarget()
 		end
 	end
 
-	return nil, nil;
+	return ContainerDropTargetType.World, frame;
 end
 
 local function slotOnDragStop(slotFrom)

--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -428,7 +428,7 @@ local function GetContainerDropTarget()
 	end
 
 	for _, frame in ipairs(frames) do
-		local name = frame:GetName() or "";
+		local name = frame:GetName() or "WorldFrame";
 
 		if name == "WorldFrame" then
 			return ContainerDropTargetType.World, frame;

--- a/totalRP3_Extended/Inventory/Container.lua
+++ b/totalRP3_Extended/Inventory/Container.lua
@@ -437,7 +437,7 @@ local function GetContainerDropTarget()
 		end
 	end
 
-	return ContainerDropTargetType.World, frame;
+	return ContainerDropTargetType.World, nil;
 end
 
 local function slotOnDragStop(slotFrom)

--- a/totalRP3_Extended/Inventory/Inventory.lua
+++ b/totalRP3_Extended/Inventory/Inventory.lua
@@ -134,7 +134,12 @@ function TRP3_API.inventory.addItem(givenContainer, classID, itemData, dropIfFul
 			freeSlot = toSlot;
 		else
 			-- Finding an empty slot
-			for i = 1, ((containerClass.CO.SR or 5) * (containerClass.CO.SC or 4)) do
+			local slotCount = (containerClass.CO.SR or 5) * (containerClass.CO.SC or 4)
+			if container == playerInventory then
+				-- Only 17 slots in the player inventory (counting the quick slot)
+				slotCount = 17;
+			end
+			for i = 1, slotCount do
 				local slotID = tostring(i);
 				if not freeSlot and not container.content[slotID] then
 					freeSlot = slotID;


### PR DESCRIPTION
- OPie adds a screen-wide frame with no name to receive mouse inputs. I thought about it and decided we'll just ignore any addon frame that's not ours, which means the error that you can't put the item here will not show anymore for now. If I have a better idea in the future, maybe I'll bring it back.

- The code to add an item falls back to the player inventory if the player has no bag, but considers it as a 20-slot bag despite it having only 17 slots. So now it doesn't shove those items in inappropriate places past the 17th slot.