### PR TITLE
Fix NPC speech punctuation in French locale

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -177,7 +177,6 @@ read_globals = {
 	"GetAchievementInfo",
 	"GetCVar",
 	"GetGuildInfo",
-	"GetLocale",
 	"GetMacroIndexByName",
 	"GetMouseFoci",
 	"GetNormalizedRealmName",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -177,6 +177,7 @@ read_globals = {
 	"GetAchievementInfo",
 	"GetCVar",
 	"GetGuildInfo",
+	"GetLocale",
 	"GetMacroIndexByName",
 	"GetMouseFoci",
 	"GetNormalizedRealmName",

--- a/totalRP3_Extended/Script/ScriptEffects.lua
+++ b/totalRP3_Extended/Script/ScriptEffects.lua
@@ -30,17 +30,26 @@ local SPEECH_CHANNEL = {
 	[SPEECH_PREFIX.EMOTES] = "EMOTE",
 }
 
-local SPEECH_SEPARATOR = GetLocale() == "frFR" and " : " or ": ";
+local function getSpeechTypePattern(speechPrefix)
+	if speechPrefix == SPEECH_PREFIX.SAYS then
+		return loc.NPC_TALK_SAY_PATTERN;
+	elseif speechPrefix == SPEECH_PREFIX.YELLS then
+		return loc.NPC_TALK_YELL_PATTERN;
+	elseif speechPrefix == SPEECH_PREFIX.WHISPERS then
+		return loc.NPC_TALK_WHISPER_PATTERN;
+	end
+end
 
 local function getSpeechPrefixText(speechPrefix, npcName, text)
-	if speechPrefix == SPEECH_PREFIX.SAYS then
-		return ("%s %s%s%s"):format(npcName, loc.NPC_SAYS, SPEECH_SEPARATOR, text);
-	elseif speechPrefix == SPEECH_PREFIX.YELLS then
-		return ("%s %s%s%s"):format(npcName, loc.NPC_YELLS, SPEECH_SEPARATOR, text);
-	elseif speechPrefix == SPEECH_PREFIX.WHISPERS then
-		return ("%s %s%s%s"):format(npcName, loc.NPC_WHISPERS, SPEECH_SEPARATOR, text);
-	elseif speechPrefix == SPEECH_PREFIX.EMOTES then
+	if speechPrefix == SPEECH_PREFIX.EMOTES then
 		return ("%s %s"):format(npcName, text);
+	end
+	local speechPattern = getSpeechTypePattern(speechPrefix);
+	if speechPattern then
+		if stEtN(npcName) then
+			return ("%s %s %s"):format(npcName, speechPattern, text);
+		end
+		return ("%s %s"):format(speechPattern, text);
 	end
 	return "(error in getSpeechPrefixText: " .. tostring(speechPrefix) .. ")";
 end

--- a/totalRP3_Extended/Script/ScriptEffects.lua
+++ b/totalRP3_Extended/Script/ScriptEffects.lua
@@ -30,13 +30,15 @@ local SPEECH_CHANNEL = {
 	[SPEECH_PREFIX.EMOTES] = "EMOTE",
 }
 
+local SPEECH_SEPARATOR = GetLocale() == "frFR" and " : " or ": ";
+
 local function getSpeechPrefixText(speechPrefix, npcName, text)
 	if speechPrefix == SPEECH_PREFIX.SAYS then
-		return ("%s %s: %s"):format(npcName, loc.NPC_SAYS, text);
+		return ("%s %s%s%s"):format(npcName, loc.NPC_SAYS, SPEECH_SEPARATOR, text);
 	elseif speechPrefix == SPEECH_PREFIX.YELLS then
-		return ("%s %s: %s"):format(npcName, loc.NPC_YELLS, text);
+		return ("%s %s%s%s"):format(npcName, loc.NPC_YELLS, SPEECH_SEPARATOR, text);
 	elseif speechPrefix == SPEECH_PREFIX.WHISPERS then
-		return ("%s %s: %s"):format(npcName, loc.NPC_WHISPERS, text);
+		return ("%s %s%s%s"):format(npcName, loc.NPC_WHISPERS, SPEECH_SEPARATOR, text);
 	elseif speechPrefix == SPEECH_PREFIX.EMOTES then
 		return ("%s %s"):format(npcName, text);
 	end


### PR DESCRIPTION
Use a locale-aware separator for NPC speech text formatting to preserve French spacing before colons while keeping the message content intact, otherwise TRP3 doesn't display the speech colored as speech but as an emote.