### PR TITLE
Fixing inspection with permanent auras

### DIFF
--- a/totalRP3_Extended/Aura/Aura.lua
+++ b/totalRP3_Extended/Aura/Aura.lua
@@ -686,7 +686,7 @@ function auraCore:GetAurasForInspection()
 					}
 				},
 				persistent = {
-					expiry = aura.persistent.expiry or math.huge
+					expiry = aura.persistent.expiry
 				}
 			});
 		end

--- a/totalRP3_Extended/Aura/Aura.lua
+++ b/totalRP3_Extended/Aura/Aura.lua
@@ -672,6 +672,12 @@ function auraCore:GetAurasForInspection()
 	local auras = {};
 	for _, aura in EnumerateValidAuras(self.activeAuras) do
 		if aura.class.BA.WE then
+			-- inf isn't supported as a serialized value, it will stay nil for inspection
+			local auraExpiryForTransfer;
+			if aura.persistent.expiry ~= math.huge then
+				auraExpiryForTransfer = aura.persistent.expiry;
+			end
+
 			tinsert(auras, {
 				class = {
 					BA = {
@@ -686,7 +692,7 @@ function auraCore:GetAurasForInspection()
 					}
 				},
 				persistent = {
-					expiry = aura.persistent.expiry
+					expiry = auraExpiryForTransfer
 				}
 			});
 		end


### PR DESCRIPTION
Permanent auras have their duration set to math.huge in the running structure (while being nil in saved variables). Due to the recent Chomp changes, math.huge is no longer a valid value to be deserialized ~~and the Lord has decreed that anyone sending those values shall be burned for all eternity~~. Everything was already set to use math.huge as duration if the field was nil, so we can simply change the data being sent for inspection.

There may be a broader pass to be made to avoid using math.huge at all and just rely on nil internally, but that can wait.

(despite the `or math.huge`, the field was not actually nil at any point, hence the change to turn math.huge into nil)